### PR TITLE
Implement ArrowRouter for orthogonal edge routing in CanvasWidget, in…

### DIFF
--- a/src/main/java/com/sbancuz/plannh/gui/ArrowRouter.java
+++ b/src/main/java/com/sbancuz/plannh/gui/ArrowRouter.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
+import java.util.UUID;
 
 /**
  * Orthogonal connector router. Routes arrows between recipe-node ports using only 90-degree segments,
@@ -45,7 +46,7 @@ public final class ArrowRouter {
     public record Rect(int x, int y, int w, int h) {}
 
     /** A single arrow to route, from a source output port to a target input port. */
-    public record Request(Object key, int sx, int sy, int dx, int dy) {}
+    public record Request(UUID key, int sx, int sy, int dx, int dy) {}
 
     private final int baseCell;
     private final int margin;
@@ -65,8 +66,8 @@ public final class ArrowRouter {
      *
      * @return a map from {@link Request#key()} to a list of {@code {x, y}} world-space waypoints
      */
-    public Map<Object, List<int[]>> route(final List<Rect> obstacles, final List<Request> requests) {
-        final Map<Object, List<int[]>> result = new HashMap<>();
+    public Map<UUID, List<int[]>> route(final List<Rect> obstacles, final List<Request> requests) {
+        final Map<UUID, List<int[]>> result = new HashMap<>();
         if (requests.isEmpty()) return result;
 
         // ── Bounding region ──
@@ -133,6 +134,10 @@ public final class ArrowRouter {
         final int originX, originY, cols, rows, cell, stub;
         final boolean[] blocked;
         final int[] occupancy;
+        final int[] gScore;
+        final int[] cameFrom;
+        final int[] scoreRun;
+        int runId = 1;
 
         Grid(final int originX, final int originY, final int cols, final int rows, final int cell, final int stub) {
             this.originX = originX;
@@ -143,6 +148,10 @@ public final class ArrowRouter {
             this.stub = stub;
             this.blocked = new boolean[cols * rows];
             this.occupancy = new int[cols * rows];
+            final int states = cols * rows * 4;
+            this.gScore = new int[states];
+            this.cameFrom = new int[states];
+            this.scoreRun = new int[states];
         }
 
         int gx(final int wx) {
@@ -190,17 +199,11 @@ public final class ArrowRouter {
         List<int[]> search(final Request q) {
             final int sgx = gx(q.sx + stub), sgy = gy(q.sy);
             final int ggx = gx(q.dx - stub), ggy = gy(q.dy);
-
-            final int n = cols * rows;
-            final int states = n * 4;
-            final int[] gScore = new int[states];
-            Arrays.fill(gScore, Integer.MAX_VALUE);
-            final int[] cameFrom = new int[states];
-            Arrays.fill(cameFrom, -1);
+            final int run = nextRun();
 
             // Start heading +x (direction 0) so the arrow leaves the output port to the right.
             final int startState = ((sgy * cols + sgx) * 4);
-            gScore[startState] = 0;
+            setScore(startState, 0, -1, run);
 
             final PriorityQueue<int[]> open = new PriorityQueue<>(Comparator.comparingInt((int[] a) -> a[0]));
             open.add(new int[] { heuristic(sgx, sgy, ggx, ggy), startState, 0 });
@@ -209,7 +212,7 @@ public final class ArrowRouter {
                 final int[] top = open.poll();
                 final int state = top[1];
                 final int g = top[2];
-                if (g > gScore[state]) continue;
+                if (g > score(state, run)) continue;
 
                 final int idx = state >> 2;
                 final int dir = state & 3;
@@ -232,9 +235,8 @@ public final class ArrowRouter {
                     final int cost = STEP + (nd != dir ? TURN : 0) + occupancy[nIdx];
                     final int ng = g + cost;
                     final int nState = nIdx * 4 + nd;
-                    if (ng < gScore[nState]) {
-                        gScore[nState] = ng;
-                        cameFrom[nState] = state;
+                    if (ng < score(nState, run)) {
+                        setScore(nState, ng, state, run);
                         open.add(new int[] { ng + heuristic(nx, ny, ggx, ggy), nState, ng });
                     }
                 }
@@ -242,8 +244,27 @@ public final class ArrowRouter {
             return null;
         }
 
+        /** Manhattan lower bound used by A* to prefer cells closer to the target. */
         private static int heuristic(final int x, final int y, final int gx, final int gy) {
             return (Math.abs(x - gx) + Math.abs(y - gy)) * STEP;
+        }
+
+        private int nextRun() {
+            if (runId == Integer.MAX_VALUE) {
+                Arrays.fill(scoreRun, 0);
+                runId = 1;
+            }
+            return runId++;
+        }
+
+        private int score(final int state, final int run) {
+            return scoreRun[state] == run ? gScore[state] : Integer.MAX_VALUE;
+        }
+
+        private void setScore(final int state, final int score, final int previousState, final int run) {
+            scoreRun[state] = run;
+            gScore[state] = score;
+            cameFrom[state] = previousState;
         }
 
         private List<int[]> reconstruct(final int[] cameFrom, final int goalState) {

--- a/src/main/java/com/sbancuz/plannh/gui/ArrowRouter.java
+++ b/src/main/java/com/sbancuz/plannh/gui/ArrowRouter.java
@@ -1,0 +1,330 @@
+package com.sbancuz.plannh.gui;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+
+/**
+ * Orthogonal connector router. Routes arrows between recipe-node ports using only 90-degree segments,
+ * avoiding node boxes and previously routed arrows, minimizing the number of bends and keeping a
+ * consistent minimum spacing between arrows and around boxes.
+ * <p>
+ * All coordinates are in graph/world space (un-zoomed, un-panned). Routing in world space keeps the
+ * produced paths stable while the user pans (a pure translation) and lets the caller cache them.
+ * <p>
+ * The router lays a uniform grid over the bounding region and runs A* where the search state is
+ * {@code (cell, incoming-direction)} so that turns can be penalized. Node rectangles inflated by a
+ * margin are hard obstacles; cells already occupied by a routed arrow carry a soft penalty so that
+ * later arrows take a parallel track instead of overlapping.
+ */
+public final class ArrowRouter {
+
+    /** Per-cell movement cost. */
+    private static final int STEP = 1;
+    /** Extra cost for changing direction. Keeps the number of bends low. */
+    private static final int TURN = 12;
+    /** Extra cost per cell that already carries another arrow. Makes arrows separate. */
+    private static final int ARROW = 4;
+    /** Smaller penalty around an occupied cell, so arrows keep at least one cell of clearance. */
+    private static final int NEAR = 1;
+
+    /** Hard cap on grid cells; the cell size is grown if a region would exceed it. */
+    private static final int MAX_CELLS = 200_000;
+    /** Padding added around the bounding region so arrows can route around outer nodes. */
+    private static final int PAD = 48;
+
+    // (+x, -x, +y, -y); reverse of d is (d ^ 1).
+    private static final int[] DX = { 1, -1, 0, 0 };
+    private static final int[] DY = { 0, 0, 1, -1 };
+
+    /** A rectangular obstacle (a recipe node) in world space. */
+    public record Rect(int x, int y, int w, int h) {}
+
+    /** A single arrow to route, from a source output port to a target input port. */
+    public record Request(Object key, int sx, int sy, int dx, int dy) {}
+
+    private final int baseCell;
+    private final int margin;
+
+    /**
+     * @param cell   nominal grid cell size in world units (also the minimum spacing granularity)
+     * @param margin clearance kept around node boxes in world units
+     */
+    public ArrowRouter(final int cell, final int margin) {
+        this.baseCell = Math.max(1, cell);
+        this.margin = Math.max(0, margin);
+    }
+
+    /**
+     * Routes every request. Requests are routed in order; each routed arrow makes the cells it uses
+     * less attractive to subsequent arrows, which spreads parallel connections apart.
+     *
+     * @return a map from {@link Request#key()} to a list of {@code {x, y}} world-space waypoints
+     */
+    public Map<Object, List<int[]>> route(final List<Rect> obstacles, final List<Request> requests) {
+        final Map<Object, List<int[]>> result = new HashMap<>();
+        if (requests.isEmpty()) return result;
+
+        // ── Bounding region ──
+        int minX = Integer.MAX_VALUE, minY = Integer.MAX_VALUE;
+        int maxX = Integer.MIN_VALUE, maxY = Integer.MIN_VALUE;
+        for (final Rect r : obstacles) {
+            minX = Math.min(minX, r.x - margin);
+            minY = Math.min(minY, r.y - margin);
+            maxX = Math.max(maxX, r.x + r.w + margin);
+            maxY = Math.max(maxY, r.y + r.h + margin);
+        }
+        final int stub = margin + baseCell;
+        for (final Request q : requests) {
+            minX = Math.min(minX, Math.min(q.sx, q.dx) - stub);
+            minY = Math.min(minY, Math.min(q.sy, q.dy));
+            maxX = Math.max(maxX, Math.max(q.sx, q.dx) + stub);
+            maxY = Math.max(maxY, Math.max(q.sy, q.dy));
+        }
+        minX -= PAD;
+        minY -= PAD;
+        maxX += PAD;
+        maxY += PAD;
+
+        // Grow the cell if the region would need too many cells.
+        int cell = baseCell;
+        int cols, rows;
+        while (true) {
+            cols = (maxX - minX) / cell + 1;
+            rows = (maxY - minY) / cell + 1;
+            if ((long) cols * rows <= MAX_CELLS || cell > 4096) break;
+            cell *= 2;
+        }
+
+        final Grid grid = new Grid(minX, minY, cols, rows, cell, stub);
+        grid.blockObstacles(obstacles, margin);
+
+        for (final Request q : requests) {
+            final List<int[]> cellPath = grid.search(q);
+            final List<int[]> path;
+            if (cellPath == null) {
+                path = fallback(q, stub);
+            } else {
+                path = grid.toWorld(cellPath, q);
+                grid.occupy(cellPath);
+            }
+            result.put(q.key, path);
+        }
+        return result;
+    }
+
+    /** Simple direct route used when A* finds no path (degenerate layouts). */
+    private static List<int[]> fallback(final Request q, final int stub) {
+        final int midX = (q.sx + stub + q.dx - stub) / 2;
+        final List<int[]> p = new ArrayList<>(4);
+        p.add(new int[] { q.sx, q.sy });
+        p.add(new int[] { midX, q.sy });
+        p.add(new int[] { midX, q.dy });
+        p.add(new int[] { q.dx, q.dy });
+        return p;
+    }
+
+    private static final class Grid {
+
+        final int originX, originY, cols, rows, cell, stub;
+        final boolean[] blocked;
+        final int[] occupancy;
+
+        Grid(final int originX, final int originY, final int cols, final int rows, final int cell, final int stub) {
+            this.originX = originX;
+            this.originY = originY;
+            this.cols = cols;
+            this.rows = rows;
+            this.cell = cell;
+            this.stub = stub;
+            this.blocked = new boolean[cols * rows];
+            this.occupancy = new int[cols * rows];
+        }
+
+        int gx(final int wx) {
+            return Math.clamp((wx - originX) / cell, 0, cols - 1);
+        }
+
+        int gy(final int wy) {
+            return Math.clamp((wy - originY) / cell, 0, rows - 1);
+        }
+
+        int centerX(final int gx) {
+            return originX + gx * cell + cell / 2;
+        }
+
+        int centerY(final int gy) {
+            return originY + gy * cell + cell / 2;
+        }
+
+        void blockObstacles(final List<Rect> obstacles, final int margin) {
+            for (final Rect r : obstacles) {
+                final int x0 = gx(r.x - margin), x1 = gx(r.x + r.w + margin);
+                final int y0 = gy(r.y - margin), y1 = gy(r.y + r.h + margin);
+                for (int y = y0; y <= y1; y++) {
+                    for (int x = x0; x <= x1; x++) {
+                        blocked[y * cols + x] = true;
+                    }
+                }
+            }
+        }
+
+        void occupy(final List<int[]> cellPath) {
+            for (final int[] c : cellPath) {
+                final int gx = c[0], gy = c[1];
+                occupancy[gy * cols + gx] += ARROW;
+                for (int d = 0; d < 4; d++) {
+                    final int nx = gx + DX[d], ny = gy + DY[d];
+                    if (nx >= 0 && nx < cols && ny >= 0 && ny < rows) {
+                        occupancy[ny * cols + nx] += NEAR;
+                    }
+                }
+            }
+        }
+
+        /** A* over (cell, direction); returns the list of {@code {gx, gy}} cells or null. */
+        List<int[]> search(final Request q) {
+            final int sgx = gx(q.sx + stub), sgy = gy(q.sy);
+            final int ggx = gx(q.dx - stub), ggy = gy(q.dy);
+
+            final int n = cols * rows;
+            final int states = n * 4;
+            final int[] gScore = new int[states];
+            Arrays.fill(gScore, Integer.MAX_VALUE);
+            final int[] cameFrom = new int[states];
+            Arrays.fill(cameFrom, -1);
+
+            // Start heading +x (direction 0) so the arrow leaves the output port to the right.
+            final int startState = ((sgy * cols + sgx) * 4);
+            gScore[startState] = 0;
+
+            final PriorityQueue<int[]> open = new PriorityQueue<>(Comparator.comparingInt((int[] a) -> a[0]));
+            open.add(new int[] { heuristic(sgx, sgy, ggx, ggy), startState, 0 });
+
+            while (!open.isEmpty()) {
+                final int[] top = open.poll();
+                final int state = top[1];
+                final int g = top[2];
+                if (g > gScore[state]) continue;
+
+                final int idx = state >> 2;
+                final int dir = state & 3;
+                final int cx = idx % cols;
+                final int cy = idx / cols;
+
+                if (cx == ggx && cy == ggy && dir == 0) {
+                    return reconstruct(cameFrom, state);
+                }
+
+                for (int nd = 0; nd < 4; nd++) {
+                    if (nd == (dir ^ 1)) continue; // no immediate U-turn
+                    final int nx = cx + DX[nd];
+                    final int ny = cy + DY[nd];
+                    if (nx < 0 || nx >= cols || ny < 0 || ny >= rows) continue;
+                    final int nIdx = ny * cols + nx;
+                    final boolean isGoal = nx == ggx && ny == ggy;
+                    if (blocked[nIdx] && !isGoal) continue;
+
+                    final int cost = STEP + (nd != dir ? TURN : 0) + occupancy[nIdx];
+                    final int ng = g + cost;
+                    final int nState = nIdx * 4 + nd;
+                    if (ng < gScore[nState]) {
+                        gScore[nState] = ng;
+                        cameFrom[nState] = state;
+                        open.add(new int[] { ng + heuristic(nx, ny, ggx, ggy), nState, ng });
+                    }
+                }
+            }
+            return null;
+        }
+
+        private static int heuristic(final int x, final int y, final int gx, final int gy) {
+            return (Math.abs(x - gx) + Math.abs(y - gy)) * STEP;
+        }
+
+        private List<int[]> reconstruct(final int[] cameFrom, final int goalState) {
+            final List<int[]> cells = new ArrayList<>();
+            int s = goalState;
+            while (s != -1) {
+                final int idx = s >> 2;
+                cells.add(new int[] { idx % cols, idx / cols });
+                s = cameFrom[s];
+            }
+            java.util.Collections.reverse(cells);
+            return cells;
+        }
+
+        /** Converts a cell path to world waypoints, snapping the stub segments to the exact ports. */
+        List<int[]> toWorld(final List<int[]> cells, final Request q) {
+            // Keep only corners (cells where the direction changes), plus the two ends.
+            final List<int[]> corners = new ArrayList<>();
+            corners.add(cells.getFirst());
+            for (int i = 1; i < cells.size() - 1; i++) {
+                final int[] a = cells.get(i - 1), b = cells.get(i), c = cells.get(i + 1);
+                final int d1x = Integer.signum(b[0] - a[0]), d1y = Integer.signum(b[1] - a[1]);
+                final int d2x = Integer.signum(c[0] - b[0]), d2y = Integer.signum(c[1] - b[1]);
+                if (d1x != d2x || d1y != d2y) corners.add(b);
+            }
+            if (cells.size() > 1) corners.add(cells.getLast());
+
+            final int m = corners.size();
+            final int[] xs = new int[m];
+            final int[] ys = new int[m];
+            for (int i = 0; i < m; i++) {
+                xs[i] = centerX(corners.get(i)[0]);
+                ys[i] = centerY(corners.get(i)[1]);
+            }
+            // Snap the source stub run to the port's exact Y (removes the half-cell jog at the port).
+            ys[0] = q.sy;
+            if (m >= 2 && corners.get(0)[1] == corners.get(1)[1]) ys[1] = q.sy;
+            // Snap the target stub run to the port's exact Y.
+            ys[m - 1] = q.dy;
+            if (m >= 2 && corners.get(m - 1)[1] == corners.get(m - 2)[1]) ys[m - 2] = q.dy;
+
+            final List<int[]> pts = new ArrayList<>(m + 2);
+            pts.add(new int[] { q.sx, q.sy });
+            for (int i = 0; i < m; i++) pts.add(new int[] { xs[i], ys[i] });
+            pts.add(new int[] { q.dx, q.dy });
+
+            return simplify(orthogonalize(pts));
+        }
+    }
+
+    /** Inserts an L-bend for any accidental diagonal so the polyline stays strictly orthogonal. */
+    private static List<int[]> orthogonalize(final List<int[]> pts) {
+        final List<int[]> out = new ArrayList<>(pts.size() + 4);
+        out.add(pts.getFirst());
+        for (int i = 1; i < pts.size(); i++) {
+            final int[] p = out.getLast();
+            final int[] c = pts.get(i);
+            if (p[0] != c[0] && p[1] != c[1]) {
+                out.add(new int[] { c[0], p[1] });
+            }
+            out.add(c);
+        }
+        return out;
+    }
+
+    /** Drops duplicate points and merges collinear runs so only real corners remain. */
+    private static List<int[]> simplify(final List<int[]> pts) {
+        final List<int[]> out = new ArrayList<>(pts.size());
+        for (final int[] p : pts) {
+            if (!out.isEmpty()) {
+                final int[] last = out.getLast();
+                if (last[0] == p[0] && last[1] == p[1]) continue;
+            }
+            out.add(p);
+        }
+        for (int i = 1; i < out.size() - 1;) {
+            final int[] a = out.get(i - 1), b = out.get(i), c = out.get(i + 1);
+            final boolean collinear = (a[0] == b[0] && b[0] == c[0]) || (a[1] == b[1] && b[1] == c[1]);
+            if (collinear) out.remove(i);
+            else i++;
+        }
+        return out;
+    }
+}

--- a/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
@@ -1,23 +1,5 @@
 package com.sbancuz.plannh.gui;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.function.IntFunction;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import net.minecraft.client.Minecraft;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.ItemStack;
-import net.minecraftforge.fluids.FluidStack;
-
-import org.lwjgl.input.Keyboard;
-import org.lwjgl.opengl.GL11;
-
 import com.cleanroommc.modularui.api.IPanelHandler;
 import com.cleanroommc.modularui.api.UpOrDown;
 import com.cleanroommc.modularui.api.widget.IWidget;
@@ -32,13 +14,19 @@ import com.cleanroommc.modularui.utils.Platform;
 import com.cleanroommc.modularui.widget.ParentWidget;
 import com.cleanroommc.modularui.widget.sizer.Area;
 import com.cleanroommc.modularui.widgets.ColorPickerDialog;
-import com.sbancuz.plannh.data.flowchart.Edge;
-import com.sbancuz.plannh.data.flowchart.Graph;
-import com.sbancuz.plannh.data.flowchart.Group;
-import com.sbancuz.plannh.data.flowchart.Node;
-import com.sbancuz.plannh.data.flowchart.Note;
-
+import com.sbancuz.plannh.data.flowchart.*;
 import lombok.Getter;
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+import org.lwjgl.input.Keyboard;
+import org.lwjgl.opengl.GL11;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.*;
+import java.util.function.IntFunction;
 
 public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interactable {
 
@@ -78,6 +66,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     // Orthogonal arrow routing (world-space units).
     private static final int ROUTE_CELL = 6;
     private static final int ROUTE_MARGIN = 12;
+    private static final long ROUTE_HASH_SEED = 1125899906842597L;
     private static final ArrowRouter ARROW_ROUTER = new ArrowRouter(ROUTE_CELL, ROUTE_MARGIN);
 
     @Nonnull
@@ -105,9 +94,11 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     private UUID edgeHoverNodeId;
     private int edgeHoverPortIndex;
 
-    /** Cached arrow routes (world-space waypoints) keyed by edge id, plus the layout they were built for. */
+    /**
+     * Cached arrow routes (world-space waypoints) keyed by edge id, plus the layout they were built for.
+     */
     private final Map<UUID, List<int[]>> edgeRoutes = new HashMap<>();
-    private String routeSignature = "";
+    private long routeSignature = Long.MIN_VALUE;
 
     public CanvasWidget(final Graph graph) {
         this.graph = graph;
@@ -147,7 +138,8 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
                         g.title.substring(5)
                             .trim());
                     if (num >= n) n = num + 1;
-                } catch (final NumberFormatException ignored) {}
+                } catch (final NumberFormatException ignored) {
+                }
             }
         }
         final Group group = new Group(x, y, "Group " + n);
@@ -383,25 +375,31 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         return Math.round(((index + 1) * PORT_SPACING + PORT_ORIGIN) * zoom);
     }
 
-    /** World-space (un-zoomed) Y of a port relative to the node's top-left corner. */
+    /**
+     * World-space (un-zoomed) Y of a port relative to the node's top-left corner.
+     */
     private static int portWorldY(final int index) {
         return (index + 1) * PORT_SPACING + PORT_ORIGIN;
     }
 
     private int worldWidth(final RecipeNodeWidget w) {
-        return Math.round(w.getArea().width / zoom);
+        return w.getWorldWidth();
     }
 
     private int worldHeight(final RecipeNodeWidget w) {
-        return Math.round(w.getArea().height / zoom);
+        return w.getWorldHeight();
     }
 
-    /** Converts a canvas-space X coordinate to world space, clamped to >= 0. */
+    /**
+     * Converts a canvas-space X coordinate to world space, clamped to >= 0.
+     */
     private int toWorldX(final int cx) {
         return Math.max(0, Math.round((cx - panX) / zoom));
     }
 
-    /** Converts a canvas-space Y coordinate to world space, clamped to >= 0. */
+    /**
+     * Converts a canvas-space Y coordinate to world space, clamped to >= 0.
+     */
     private int toWorldY(final int cy) {
         return Math.max(0, Math.round((cy - panY) / zoom));
     }
@@ -410,45 +408,18 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         return mx >= a.x && mx < a.x + a.width && my >= a.y && my < a.y + a.height;
     }
 
+    private static boolean containsPointInclusive(final Area a, final int mx, final int my) {
+        return mx >= a.x && mx <= a.x + a.width && my >= a.y && my <= a.y + a.height;
+    }
+
     /**
-     * Recomputes orthogonal arrow routes when the layout (node positions/sizes, edges or zoom) changes.
+     * Recomputes orthogonal arrow routes when the graph layout changes.
      * Routes are stored in world space so panning does not invalidate them.
      */
     private void ensureRoutes() {
-        final StringBuilder sig = new StringBuilder();
-        sig.append('z')
-            .append(Math.round(zoom * 100))
-            .append(';');
-        for (final Edge edge : graph.getEdges()) {
-            final RecipeNodeWidget src = nodeWidgets.get(edge.sourceNodeId);
-            final RecipeNodeWidget dst = nodeWidgets.get(edge.targetNodeId);
-            if (src == null || dst == null) continue;
-            sig.append(edge.id)
-                .append(':')
-                .append(edge.sourceOutputIndex)
-                .append('>')
-                .append(edge.targetInputIndex)
-                .append('|')
-                .append(src.getNode().x)
-                .append(',')
-                .append(src.getNode().y)
-                .append(',')
-                .append(worldWidth(src))
-                .append(',')
-                .append(worldHeight(src))
-                .append('|')
-                .append(dst.getNode().x)
-                .append(',')
-                .append(dst.getNode().y)
-                .append(',')
-                .append(worldWidth(dst))
-                .append(',')
-                .append(worldHeight(dst))
-                .append(';');
-        }
-        final String s = sig.toString();
-        if (s.equals(routeSignature)) return;
-        routeSignature = s;
+        final long signature = computeRouteSignature();
+        if (signature == routeSignature) return;
+        routeSignature = signature;
 
         edgeRoutes.clear();
         final List<ArrowRouter.Rect> obstacles = new ArrayList<>();
@@ -467,10 +438,33 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
             requests.add(new ArrowRouter.Request(edge.id, sx, sy, dx, dy));
         }
 
-        final Map<Object, List<int[]>> routed = ARROW_ROUTER.route(obstacles, requests);
-        for (final Map.Entry<Object, List<int[]>> e : routed.entrySet()) {
-            edgeRoutes.put((UUID) e.getKey(), e.getValue());
+        edgeRoutes.putAll(ARROW_ROUTER.route(obstacles, requests));
+    }
+
+    private long computeRouteSignature() {
+        long sig = ROUTE_HASH_SEED;
+        for (final Edge edge : graph.getEdges()) {
+            final RecipeNodeWidget src = nodeWidgets.get(edge.sourceNodeId);
+            final RecipeNodeWidget dst = nodeWidgets.get(edge.targetNodeId);
+            if (src == null || dst == null) continue;
+            sig = mixRouteHash(sig, edge.id.getMostSignificantBits());
+            sig = mixRouteHash(sig, edge.id.getLeastSignificantBits());
+            sig = mixRouteHash(sig, edge.sourceOutputIndex);
+            sig = mixRouteHash(sig, edge.targetInputIndex);
+            sig = mixRouteHash(sig, src.getNode().x);
+            sig = mixRouteHash(sig, src.getNode().y);
+            sig = mixRouteHash(sig, worldWidth(src));
+            sig = mixRouteHash(sig, worldHeight(src));
+            sig = mixRouteHash(sig, dst.getNode().x);
+            sig = mixRouteHash(sig, dst.getNode().y);
+            sig = mixRouteHash(sig, worldWidth(dst));
+            sig = mixRouteHash(sig, worldHeight(dst));
         }
+        return sig;
+    }
+
+    private static long mixRouteHash(final long hash, final long value) {
+        return hash * 31 + value;
     }
 
     private void drawArrows() {
@@ -498,7 +492,9 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         }
     }
 
-    /** Draws a multi-segment orthogonal arrow from cached world-space waypoints. */
+    /**
+     * Draws a multi-segment orthogonal arrow from cached world-space waypoints.
+     */
     private void drawRoutedArrow(final List<int[]> route, final boolean fluid) {
         final int n = route.size();
         final int[] sx = new int[n];
@@ -550,9 +546,9 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     }
 
     private void drawOrthogonalLine(final int x1, final int y1, final int x2, final int y2, final int xEnd,
-        final int color, final float thickness) {
+                                    final int color, final float thickness) {
         final int midX = (x1 + x2) / 2;
-        drawLineStrip(new int[] { x1, midX, midX, xEnd }, new int[] { y1, y1, y2, y2 }, color, thickness);
+        drawLineStrip(new int[]{x1, midX, midX, xEnd}, new int[]{y1, y1, y2, y2}, color, thickness);
     }
 
     private static void drawLineStrip(final int[] xs, final int[] ys, final int color, final float thickness) {
@@ -571,7 +567,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     }
 
     private static void drawArrowHead(final int tipX, final int tipY, final int baseX, final float halfBase,
-        final int color) {
+                                      final int color) {
         final int r = Color.getRed(color);
         final int g = Color.getGreen(color);
         final int b = Color.getBlue(color);
@@ -585,7 +581,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     }
 
     private static void addColoredVertex(final BufferBuilder buf, final int x, final int y, final int r, final int g,
-        final int b, final int a) {
+                                         final int b, final int a) {
         buf.pos(x, y, 0)
             .color(r, g, b, a)
             .endVertex();
@@ -813,7 +809,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     private boolean isMouseOverAnyGroup(final int mx, final int my) {
         for (final GroupWidget gw : groupWidgets.values()) {
             final Area a = gw.getArea();
-            if (containsPoint(a, mx, my)) {
+            if (containsPointInclusive(a, mx, my)) {
                 return true;
             }
         }
@@ -823,7 +819,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     private boolean isMouseOverAnyNode(final int mx, final int my) {
         for (final RecipeNodeWidget widget : nodeWidgets.values()) {
             final Area a = widget.getArea();
-            if (containsPoint(a, mx, my)) {
+            if (containsPointInclusive(a, mx, my)) {
                 return true;
             }
         }
@@ -958,7 +954,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
             .simple(
                 getPanel(),
                 (@SuppressWarnings("unused") final ModularPanel parentPanel,
-                    @SuppressWarnings("unused") final EntityPlayer player) -> picker,
+                 @SuppressWarnings("unused") final EntityPlayer player) -> picker,
                 true)
             .openPanel();
     }
@@ -1021,7 +1017,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     private void drawHoveredPortLabels() {
         final int mouseX = getContext().getMouseX();
         final int mouseY = getContext().getMouseY();
-        final int ps = Math.round(PORT_S * zoom);
+        final int ps = Math.max(1, Math.round(PORT_S * zoom));
         final int half = Math.round(PORT_HALF * zoom);
 
         for (final RecipeNodeWidget w : nodeWidgets.values()) {
@@ -1042,10 +1038,13 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
                 node.outputs.size(),
                 0,
                 true,
-                i -> node.outputs.get(i)
-                    .left()
-                    .getDisplayName()))
+                i -> {
+                    final ItemStack stack = node.outputs.get(i)
+                        .left();
+                    return stack == null ? null : stack.getDisplayName();
+                })) {
                 return;
+            }
             if (tryPortLabel(
                 mouseX,
                 mouseY,
@@ -1058,10 +1057,13 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
                 node.fluidOutputs.size(),
                 node.outputs.size(),
                 true,
-                i -> node.fluidOutputs.get(i)
-                    .left()
-                    .getLocalizedName()))
+                i -> {
+                    final FluidStack stack = node.fluidOutputs.get(i)
+                        .left();
+                    return stack == null ? null : stack.getLocalizedName();
+                })) {
                 return;
+            }
             if (tryPortLabel(
                 mouseX,
                 mouseY,
@@ -1074,10 +1076,13 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
                 node.inputs.size(),
                 0,
                 false,
-                i -> node.inputs.get(i)
-                    .left()
-                    .getDisplayName()))
+                i -> {
+                    final ItemStack stack = node.inputs.get(i)
+                        .left();
+                    return stack == null ? null : stack.getDisplayName();
+                })) {
                 return;
+            }
             if (tryPortLabel(
                 mouseX,
                 mouseY,
@@ -1090,22 +1095,29 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
                 node.fluidInputs.size(),
                 node.inputs.size(),
                 false,
-                i -> node.fluidInputs.get(i)
-                    .left()
-                    .getLocalizedName()))
+                i -> {
+                    final FluidStack stack = node.fluidInputs.get(i)
+                        .left();
+                    return stack == null ? null : stack.getLocalizedName();
+                })) {
                 return;
+            }
         }
     }
 
     private boolean tryPortLabel(final int mouseX, final int mouseY, final float zoom, final int ps, final int half,
-        final int widgetX, final int widgetY, final int widgetWidth, final int portCount, final int portOffset,
-        final boolean rightSide, final IntFunction<String> labelFn) {
+                                 final int widgetX, final int widgetY, final int widgetWidth, final int portCount, final int portOffset,
+                                 final boolean rightSide, final IntFunction<String> labelFn) {
         for (int i = 0; i < portCount; i++) {
             final int fi = portOffset + i;
             final int px = rightSide ? widgetX + widgetWidth - ps : widgetX;
             final int pcY = widgetY + portY(fi);
-            if (mouseX >= px && mouseX < px + ps && mouseY >= pcY - half && mouseY < pcY + half) {
-                drawPortLabel(labelFn.apply(i), rightSide ? widgetX + widgetWidth : widgetX, pcY, rightSide, zoom);
+            final int py = pcY - half;
+            if (mouseX >= px && mouseX < px + ps && mouseY >= py && mouseY < py + ps) {
+                final String label = labelFn.apply(i);
+                if (label != null) {
+                    drawPortLabel(label, rightSide ? widgetX + widgetWidth : widgetX, pcY, rightSide, zoom);
+                }
                 return true;
             }
         }
@@ -1113,7 +1125,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     }
 
     private static void drawPortLabel(String name, final int anchorX, final int centerY, final boolean rightSide,
-        final float z) {
+                                      final float z) {
         if (name.length() > PORT_LABEL_MAX) name = name.substring(0, PORT_LABEL_TRUNC) + "…";
         final int tw = Minecraft.getMinecraft().fontRenderer.getStringWidth(name);
         final int fh = Math.round(PORT_FONT_SIZE * z * PORT_FONT_SCALE);

--- a/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
@@ -1,5 +1,23 @@
 package com.sbancuz.plannh.gui;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.IntFunction;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+
+import org.lwjgl.input.Keyboard;
+import org.lwjgl.opengl.GL11;
+
 import com.cleanroommc.modularui.api.IPanelHandler;
 import com.cleanroommc.modularui.api.UpOrDown;
 import com.cleanroommc.modularui.api.widget.IWidget;
@@ -14,19 +32,13 @@ import com.cleanroommc.modularui.utils.Platform;
 import com.cleanroommc.modularui.widget.ParentWidget;
 import com.cleanroommc.modularui.widget.sizer.Area;
 import com.cleanroommc.modularui.widgets.ColorPickerDialog;
-import com.sbancuz.plannh.data.flowchart.*;
-import lombok.Getter;
-import net.minecraft.client.Minecraft;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.ItemStack;
-import net.minecraftforge.fluids.FluidStack;
-import org.lwjgl.input.Keyboard;
-import org.lwjgl.opengl.GL11;
+import com.sbancuz.plannh.data.flowchart.Edge;
+import com.sbancuz.plannh.data.flowchart.Graph;
+import com.sbancuz.plannh.data.flowchart.Group;
+import com.sbancuz.plannh.data.flowchart.Node;
+import com.sbancuz.plannh.data.flowchart.Note;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.*;
-import java.util.function.IntFunction;
+import lombok.Getter;
 
 public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interactable {
 
@@ -138,8 +150,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
                         g.title.substring(5)
                             .trim());
                     if (num >= n) n = num + 1;
-                } catch (final NumberFormatException ignored) {
-                }
+                } catch (final NumberFormatException ignored) {}
             }
         }
         final Group group = new Group(x, y, "Group " + n);
@@ -546,9 +557,9 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     }
 
     private void drawOrthogonalLine(final int x1, final int y1, final int x2, final int y2, final int xEnd,
-                                    final int color, final float thickness) {
+        final int color, final float thickness) {
         final int midX = (x1 + x2) / 2;
-        drawLineStrip(new int[]{x1, midX, midX, xEnd}, new int[]{y1, y1, y2, y2}, color, thickness);
+        drawLineStrip(new int[] { x1, midX, midX, xEnd }, new int[] { y1, y1, y2, y2 }, color, thickness);
     }
 
     private static void drawLineStrip(final int[] xs, final int[] ys, final int color, final float thickness) {
@@ -567,7 +578,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     }
 
     private static void drawArrowHead(final int tipX, final int tipY, final int baseX, final float halfBase,
-                                      final int color) {
+        final int color) {
         final int r = Color.getRed(color);
         final int g = Color.getGreen(color);
         final int b = Color.getBlue(color);
@@ -581,7 +592,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     }
 
     private static void addColoredVertex(final BufferBuilder buf, final int x, final int y, final int r, final int g,
-                                         final int b, final int a) {
+        final int b, final int a) {
         buf.pos(x, y, 0)
             .color(r, g, b, a)
             .endVertex();
@@ -954,7 +965,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
             .simple(
                 getPanel(),
                 (@SuppressWarnings("unused") final ModularPanel parentPanel,
-                 @SuppressWarnings("unused") final EntityPlayer player) -> picker,
+                    @SuppressWarnings("unused") final EntityPlayer player) -> picker,
                 true)
             .openPanel();
     }
@@ -1106,8 +1117,8 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     }
 
     private boolean tryPortLabel(final int mouseX, final int mouseY, final float zoom, final int ps, final int half,
-                                 final int widgetX, final int widgetY, final int widgetWidth, final int portCount, final int portOffset,
-                                 final boolean rightSide, final IntFunction<String> labelFn) {
+        final int widgetX, final int widgetY, final int widgetWidth, final int portCount, final int portOffset,
+        final boolean rightSide, final IntFunction<String> labelFn) {
         for (int i = 0; i < portCount; i++) {
             final int fi = portOffset + i;
             final int px = rightSide ? widgetX + widgetWidth - ps : widgetX;
@@ -1125,7 +1136,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     }
 
     private static void drawPortLabel(String name, final int anchorX, final int centerY, final boolean rightSide,
-                                      final float z) {
+        final float z) {
         if (name.length() > PORT_LABEL_MAX) name = name.substring(0, PORT_LABEL_TRUNC) + "…";
         final int tw = Minecraft.getMinecraft().fontRenderer.getStringWidth(name);
         final int fh = Math.round(PORT_FONT_SIZE * z * PORT_FONT_SCALE);

--- a/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
@@ -11,6 +11,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
@@ -19,8 +20,11 @@ import org.lwjgl.opengl.GL11;
 
 import com.cleanroommc.modularui.api.IPanelHandler;
 import com.cleanroommc.modularui.api.UpOrDown;
+import com.cleanroommc.modularui.api.widget.IWidget;
 import com.cleanroommc.modularui.api.widget.Interactable;
+import com.cleanroommc.modularui.drawable.BufferBuilder;
 import com.cleanroommc.modularui.drawable.GuiDraw;
+import com.cleanroommc.modularui.screen.ModularPanel;
 import com.cleanroommc.modularui.screen.viewport.ModularGuiContext;
 import com.cleanroommc.modularui.theme.WidgetThemeEntry;
 import com.cleanroommc.modularui.utils.Color;
@@ -66,6 +70,16 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     private static final float PORT_FONT_SCALE = 0.9f;
     private static final int PORT_LABEL_PAD = 2;
 
+    private static final int GROUP_FIT_PAD = 12;
+    private static final float ZOOM_STEP = 0.15f;
+    private static final float ZOOM_MIN = 0.1f;
+    private static final float ZOOM_MAX = 5.0f;
+
+    // Orthogonal arrow routing (world-space units).
+    private static final int ROUTE_CELL = 6;
+    private static final int ROUTE_MARGIN = 12;
+    private static final ArrowRouter ARROW_ROUTER = new ArrowRouter(ROUTE_CELL, ROUTE_MARGIN);
+
     @Nonnull
     @Getter
     private Graph graph;
@@ -90,6 +104,10 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     private int edgeEndX, edgeEndY;
     private UUID edgeHoverNodeId;
     private int edgeHoverPortIndex;
+
+    /** Cached arrow routes (world-space waypoints) keyed by edge id, plus the layout they were built for. */
+    private final Map<UUID, List<int[]>> edgeRoutes = new HashMap<>();
+    private String routeSignature = "";
 
     public CanvasWidget(final Graph graph) {
         this.graph = graph;
@@ -134,10 +152,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         }
         final Group group = new Group(x, y, "Group " + n);
         graph.addGroup(group);
-        final GroupWidget gw = new GroupWidget(group, this);
-        gw.syncTransform(zoom, panX, panY);
-        groupWidgets.put(group.id, gw);
-        child(gw);
+        addGroupWidget(group);
     }
 
     public void moveGroupNodes(final UUID groupId, final int deltaX, final int deltaY) {
@@ -163,10 +178,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
                 if (nodeWidgets.containsKey(nodeId)) continue;
                 final Node node = graph.nodes.get(nodeId);
                 if (node == null) continue;
-                final RecipeNodeWidget w = new RecipeNodeWidget(node, this);
-                w.syncTransform(zoom, panX, panY);
-                nodeWidgets.put(nodeId, w);
-                child(w);
+                addNodeWidget(node);
             } else {
                 final RecipeNodeWidget w = nodeWidgets.remove(nodeId);
                 if (w != null) remove(w);
@@ -209,7 +221,6 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
 
     public void fitGroupToChildren(final Group group) {
         if (group.nodeIds.isEmpty()) return;
-        final int pad = 12;
         int minX = Integer.MAX_VALUE, minY = Integer.MAX_VALUE;
         int maxX = Integer.MIN_VALUE, maxY = Integer.MIN_VALUE;
         for (final UUID nid : group.nodeIds) {
@@ -221,10 +232,10 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
             if (n.y + NODE_H_ESTIMATE > maxY) maxY = n.y + NODE_H_ESTIMATE;
         }
         if (minX == Integer.MAX_VALUE) return;
-        group.x = minX - pad;
-        group.y = minY - pad;
-        group.width = maxX - minX + pad * 2;
-        group.height = maxY - minY + pad * 2;
+        group.x = minX - GROUP_FIT_PAD;
+        group.y = minY - GROUP_FIT_PAD;
+        group.width = maxX - minX + GROUP_FIT_PAD * 2;
+        group.height = maxY - minY + GROUP_FIT_PAD * 2;
         final GroupWidget gw = groupWidgets.get(group.id);
         if (gw != null) {
             gw.syncTransform(zoom, panX, panY);
@@ -262,45 +273,55 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         groupWidgets.clear();
         noteWidgets.clear();
         for (final Group group : graph.getGroups()) {
-            final GroupWidget gw = new GroupWidget(group, this);
-            gw.syncTransform(zoom, panX, panY);
-            groupWidgets.put(group.id, gw);
-            child(gw);
+            addGroupWidget(group);
         }
         for (final Node node : graph.getNodes()) {
-            final RecipeNodeWidget widget = new RecipeNodeWidget(node, this);
-            widget.syncTransform(zoom, panX, panY);
-            nodeWidgets.put(node.id, widget);
-            child(widget);
+            addNodeWidget(node);
             updateNodeGroupMembership(node);
         }
         rebuildNoteWidgets();
     }
 
     public void rebuildGroupWidgets() {
-        for (final GroupWidget gw : groupWidgets.values()) {
-            remove(gw);
-        }
-        groupWidgets.clear();
+        clearWidgetMap(groupWidgets);
         for (final Group group : graph.getGroups()) {
-            final GroupWidget gw = new GroupWidget(group, this);
-            gw.syncTransform(zoom, panX, panY);
-            groupWidgets.put(group.id, gw);
-            child(gw);
+            addGroupWidget(group);
         }
     }
 
     public void rebuildNoteWidgets() {
-        for (final NoteWidget nw : noteWidgets.values()) {
-            remove(nw);
-        }
-        noteWidgets.clear();
+        clearWidgetMap(noteWidgets);
         for (final Note note : graph.notes.values()) {
-            final NoteWidget nw = new NoteWidget(note, this);
-            nw.syncTransform(zoom, panX, panY);
-            noteWidgets.put(note.id, nw);
-            child(nw);
+            addNoteWidget(note);
         }
+    }
+
+    private void clearWidgetMap(final Map<UUID, ? extends IWidget> widgets) {
+        for (final IWidget widget : widgets.values()) {
+            remove(widget);
+        }
+        widgets.clear();
+    }
+
+    private void addGroupWidget(final Group group) {
+        final GroupWidget gw = new GroupWidget(group, this);
+        gw.syncTransform(zoom, panX, panY);
+        groupWidgets.put(group.id, gw);
+        child(gw);
+    }
+
+    private void addNodeWidget(final Node node) {
+        final RecipeNodeWidget widget = new RecipeNodeWidget(node, this);
+        widget.syncTransform(zoom, panX, panY);
+        nodeWidgets.put(node.id, widget);
+        child(widget);
+    }
+
+    private void addNoteWidget(final Note note) {
+        final NoteWidget nw = new NoteWidget(note, this);
+        nw.syncTransform(zoom, panX, panY);
+        noteWidgets.put(note.id, nw);
+        child(nw);
     }
 
     private void updatePositions() {
@@ -362,7 +383,98 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         return Math.round(((index + 1) * PORT_SPACING + PORT_ORIGIN) * zoom);
     }
 
+    /** World-space (un-zoomed) Y of a port relative to the node's top-left corner. */
+    private static int portWorldY(final int index) {
+        return (index + 1) * PORT_SPACING + PORT_ORIGIN;
+    }
+
+    private int worldWidth(final RecipeNodeWidget w) {
+        return Math.round(w.getArea().width / zoom);
+    }
+
+    private int worldHeight(final RecipeNodeWidget w) {
+        return Math.round(w.getArea().height / zoom);
+    }
+
+    /** Converts a canvas-space X coordinate to world space, clamped to >= 0. */
+    private int toWorldX(final int cx) {
+        return Math.max(0, Math.round((cx - panX) / zoom));
+    }
+
+    /** Converts a canvas-space Y coordinate to world space, clamped to >= 0. */
+    private int toWorldY(final int cy) {
+        return Math.max(0, Math.round((cy - panY) / zoom));
+    }
+
+    private static boolean containsPoint(final Area a, final int mx, final int my) {
+        return mx >= a.x && mx < a.x + a.width && my >= a.y && my < a.y + a.height;
+    }
+
+    /**
+     * Recomputes orthogonal arrow routes when the layout (node positions/sizes, edges or zoom) changes.
+     * Routes are stored in world space so panning does not invalidate them.
+     */
+    private void ensureRoutes() {
+        final StringBuilder sig = new StringBuilder();
+        sig.append('z')
+            .append(Math.round(zoom * 100))
+            .append(';');
+        for (final Edge edge : graph.getEdges()) {
+            final RecipeNodeWidget src = nodeWidgets.get(edge.sourceNodeId);
+            final RecipeNodeWidget dst = nodeWidgets.get(edge.targetNodeId);
+            if (src == null || dst == null) continue;
+            sig.append(edge.id)
+                .append(':')
+                .append(edge.sourceOutputIndex)
+                .append('>')
+                .append(edge.targetInputIndex)
+                .append('|')
+                .append(src.getNode().x)
+                .append(',')
+                .append(src.getNode().y)
+                .append(',')
+                .append(worldWidth(src))
+                .append(',')
+                .append(worldHeight(src))
+                .append('|')
+                .append(dst.getNode().x)
+                .append(',')
+                .append(dst.getNode().y)
+                .append(',')
+                .append(worldWidth(dst))
+                .append(',')
+                .append(worldHeight(dst))
+                .append(';');
+        }
+        final String s = sig.toString();
+        if (s.equals(routeSignature)) return;
+        routeSignature = s;
+
+        edgeRoutes.clear();
+        final List<ArrowRouter.Rect> obstacles = new ArrayList<>();
+        for (final RecipeNodeWidget w : nodeWidgets.values()) {
+            obstacles.add(new ArrowRouter.Rect(w.getNode().x, w.getNode().y, worldWidth(w), worldHeight(w)));
+        }
+        final List<ArrowRouter.Request> requests = new ArrayList<>();
+        for (final Edge edge : graph.getEdges()) {
+            final RecipeNodeWidget src = nodeWidgets.get(edge.sourceNodeId);
+            final RecipeNodeWidget dst = nodeWidgets.get(edge.targetNodeId);
+            if (src == null || dst == null) continue;
+            final int sx = src.getNode().x + worldWidth(src);
+            final int sy = src.getNode().y + portWorldY(edge.sourceOutputIndex);
+            final int dx = dst.getNode().x;
+            final int dy = dst.getNode().y + portWorldY(edge.targetInputIndex);
+            requests.add(new ArrowRouter.Request(edge.id, sx, sy, dx, dy));
+        }
+
+        final Map<Object, List<int[]>> routed = ARROW_ROUTER.route(obstacles, requests);
+        for (final Map.Entry<Object, List<int[]>> e : routed.entrySet()) {
+            edgeRoutes.put((UUID) e.getKey(), e.getValue());
+        }
+    }
+
     private void drawArrows() {
+        ensureRoutes();
         for (final Edge edge : graph.getEdges()) {
             final RecipeNodeWidget srcWidget = nodeWidgets.get(edge.sourceNodeId);
             final RecipeNodeWidget dstWidget = nodeWidgets.get(edge.targetNodeId);
@@ -370,6 +482,12 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
 
             final Node srcNode = graph.nodes.get(edge.sourceNodeId);
             final boolean isFluid = srcNode != null && edge.sourceOutputIndex >= srcNode.outputs.size();
+
+            final List<int[]> route = edgeRoutes.get(edge.id);
+            if (route != null && route.size() >= 2) {
+                drawRoutedArrow(route, isFluid);
+                continue;
+            }
 
             final int srcX = widgetX(srcWidget) + srcWidget.getArea().width;
             final int srcY = widgetY(srcWidget) + portY(edge.sourceOutputIndex);
@@ -380,28 +498,34 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         }
     }
 
+    /** Draws a multi-segment orthogonal arrow from cached world-space waypoints. */
+    private void drawRoutedArrow(final List<int[]> route, final boolean fluid) {
+        final int n = route.size();
+        final int[] sx = new int[n];
+        final int[] sy = new int[n];
+        for (int i = 0; i < n; i++) {
+            sx[i] = Math.round(route.get(i)[0] * zoom + panX);
+            sy[i] = Math.round(route.get(i)[1] * zoom + panY);
+        }
+
+        final float as = Math.max(ARROW_MIN_SIZE, ARROW_SIZE * zoom);
+        final int color = fluid ? ARROW_COLOR_FLUID : ARROW_COLOR_ITEM;
+        final int x2 = sx[n - 1];
+        final int y2 = sy[n - 1];
+        // Stop the line at the arrow base so it does not poke through the head (last segment is horizontal).
+        sx[n - 1] = Math.round(x2 - as);
+
+        drawLineStrip(sx, sy, color, Math.max(LINE_THICK_MIN, LINE_THICK_BASE * zoom));
+        drawArrowHead(x2, y2, sx[n - 1], as * ARROW_HB_RATIO, color);
+    }
+
     private void drawArrow(final int x1, final int y1, final int x2, final int y2, final boolean fluid) {
         final float as = Math.max(ARROW_MIN_SIZE, ARROW_SIZE * zoom);
         final int ex = Math.round(x2 - as);
         final int color = fluid ? ARROW_COLOR_FLUID : ARROW_COLOR_ITEM;
         drawOrthogonalLine(x1, y1, x2, y2, ex, color, Math.max(LINE_THICK_MIN, LINE_THICK_BASE * zoom));
 
-        final int r = Color.getRed(color);
-        final int g = Color.getGreen(color);
-        final int b = Color.getBlue(color);
-        final int a = Color.getAlpha(color);
-        final float hb = as * ARROW_HB_RATIO;
-        Platform.startDrawing(Platform.DrawMode.TRIANGLES, Platform.VertexFormat.POS_COLOR, buf -> {
-            buf.pos(x2, y2, 0)
-                .color(r, g, b, a)
-                .endVertex();
-            buf.pos(ex, Math.round(y2 - hb), 0)
-                .color(r, g, b, a)
-                .endVertex();
-            buf.pos(ex, Math.round(y2 + hb), 0)
-                .color(r, g, b, a)
-                .endVertex();
-        });
+        drawArrowHead(x2, y2, ex, as * ARROW_HB_RATIO, color);
     }
 
     private void drawPreviewLine() {
@@ -428,55 +552,66 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     private void drawOrthogonalLine(final int x1, final int y1, final int x2, final int y2, final int xEnd,
         final int color, final float thickness) {
         final int midX = (x1 + x2) / 2;
+        drawLineStrip(new int[] { x1, midX, midX, xEnd }, new int[] { y1, y1, y2, y2 }, color, thickness);
+    }
+
+    private static void drawLineStrip(final int[] xs, final int[] ys, final int color, final float thickness) {
         final int r = Color.getRed(color);
         final int g = Color.getGreen(color);
         final int b = Color.getBlue(color);
         final int a = Color.getAlpha(color);
-
         Platform.setupDrawColor();
         GL11.glLineWidth(thickness);
         Platform.startDrawing(Platform.DrawMode.LINE_STRIP, Platform.VertexFormat.POS_COLOR, buf -> {
-            buf.pos(x1, y1, 0)
-                .color(r, g, b, a)
-                .endVertex();
-            buf.pos(midX, y1, 0)
-                .color(r, g, b, a)
-                .endVertex();
-            buf.pos(midX, y2, 0)
-                .color(r, g, b, a)
-                .endVertex();
-            buf.pos(xEnd, y2, 0)
-                .color(r, g, b, a)
-                .endVertex();
+            for (int i = 0; i < xs.length; i++) {
+                addColoredVertex(buf, xs[i], ys[i], r, g, b, a);
+            }
         });
         GL11.glLineWidth(1);
     }
 
+    private static void drawArrowHead(final int tipX, final int tipY, final int baseX, final float halfBase,
+        final int color) {
+        final int r = Color.getRed(color);
+        final int g = Color.getGreen(color);
+        final int b = Color.getBlue(color);
+        final int a = Color.getAlpha(color);
+        Platform.setupDrawColor();
+        Platform.startDrawing(Platform.DrawMode.TRIANGLES, Platform.VertexFormat.POS_COLOR, buf -> {
+            addColoredVertex(buf, tipX, tipY, r, g, b, a);
+            addColoredVertex(buf, baseX, Math.round(tipY - halfBase), r, g, b, a);
+            addColoredVertex(buf, baseX, Math.round(tipY + halfBase), r, g, b, a);
+        });
+    }
+
+    private static void addColoredVertex(final BufferBuilder buf, final int x, final int y, final int r, final int g,
+        final int b, final int a) {
+        buf.pos(x, y, 0)
+            .color(r, g, b, a)
+            .endVertex();
+    }
+
     @Nullable
     private Edge getEdgeAt(final int absMx, final int absMy) {
+        ensureRoutes();
         final int margin = Math.max(EDGE_MARGIN_BASE, Math.round(EDGE_MARGIN_BASE * zoom));
         final int cmx = absMx - getArea().x;
         final int cmy = absMy - getArea().y;
         for (final Edge edge : graph.getEdges()) {
-            final RecipeNodeWidget srcWidget = nodeWidgets.get(edge.sourceNodeId);
-            final RecipeNodeWidget dstWidget = nodeWidgets.get(edge.targetNodeId);
-            if (srcWidget == null || dstWidget == null) continue;
-
-            final int x1 = widgetX(srcWidget) + srcWidget.getArea().width;
-            final int y1 = widgetY(srcWidget) + portY(edge.sourceOutputIndex);
-            final int x2 = widgetX(dstWidget);
-            final int y2 = widgetY(dstWidget) + portY(edge.targetInputIndex);
-            final int midX = (x1 + x2) / 2;
-
-            if (cmx >= Math.min(x1, midX) - margin && cmx <= Math.max(x1, midX) + margin
-                && cmy >= y1 - margin
-                && cmy <= y1 + margin) return edge;
-            if (cmx >= midX - margin && cmx <= midX + margin
-                && cmy >= Math.min(y1, y2) - margin
-                && cmy <= Math.max(y1, y2) + margin) return edge;
-            if (cmx >= Math.min(midX, x2) - margin && cmx <= Math.max(midX, x2) + margin
-                && cmy >= y2 - margin
-                && cmy <= y2 + margin) return edge;
+            final List<int[]> route = edgeRoutes.get(edge.id);
+            if (route == null || route.size() < 2) continue;
+            for (int i = 0; i < route.size() - 1; i++) {
+                final int x1 = Math.round(route.get(i)[0] * zoom + panX);
+                final int y1 = Math.round(route.get(i)[1] * zoom + panY);
+                final int x2 = Math.round(route.get(i + 1)[0] * zoom + panX);
+                final int y2 = Math.round(route.get(i + 1)[1] * zoom + panY);
+                // Segments are axis-aligned, so this is a simple inflated-rectangle test.
+                if (cmx >= Math.min(x1, x2) - margin && cmx <= Math.max(x1, x2) + margin
+                    && cmy >= Math.min(y1, y2) - margin
+                    && cmy <= Math.max(y1, y2) + margin) {
+                    return edge;
+                }
+            }
         }
         return null;
     }
@@ -565,7 +700,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
             // Check if over a group header (pass click through for its own right-click menu)
             for (final GroupWidget gw : groupWidgets.values()) {
                 final Area a = gw.getArea();
-                if (absMx >= a.x && absMx < a.x + a.width && absMy >= a.y && absMy < a.y + a.height) {
+                if (containsPoint(a, absMx, absMy)) {
                     showGroupContextMenu(gw, cmx, cmy);
                     return Result.SUCCESS;
                 }
@@ -574,7 +709,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
             // Check if over a node
             for (final RecipeNodeWidget widget : nodeWidgets.values()) {
                 final Area a = widget.getArea();
-                if (absMx >= a.x && absMx < a.x + a.width && absMy >= a.y && absMy < a.y + a.height) {
+                if (containsPoint(a, absMx, absMy)) {
                     showNodeContextMenu(widget, cmx, cmy);
                     return Result.SUCCESS;
                 }
@@ -656,10 +791,10 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
 
     @Override
     public boolean onMouseScroll(final UpOrDown direction, final int amount) {
-        float delta = direction == UpOrDown.UP ? 0.15f : -0.15f;
+        float delta = direction == UpOrDown.UP ? ZOOM_STEP : -ZOOM_STEP;
         delta *= Math.max(1, Math.abs(amount));
         final float oldZoom = zoom;
-        zoom = Math.clamp(zoom + delta, 0.1f, 5.0f);
+        zoom = Math.clamp(zoom + delta, ZOOM_MIN, ZOOM_MAX);
         final float ratio = zoom / oldZoom;
 
         final int mx = getContext().getAbsMouseX();
@@ -678,7 +813,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     private boolean isMouseOverAnyGroup(final int mx, final int my) {
         for (final GroupWidget gw : groupWidgets.values()) {
             final Area a = gw.getArea();
-            if (mx >= a.x && mx <= a.x + a.width && my >= a.y && my <= a.y + a.height) {
+            if (containsPoint(a, mx, my)) {
                 return true;
             }
         }
@@ -688,7 +823,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     private boolean isMouseOverAnyNode(final int mx, final int my) {
         for (final RecipeNodeWidget widget : nodeWidgets.values()) {
             final Area a = widget.getArea();
-            if (mx >= a.x && mx <= a.x + a.width && my >= a.y && my <= a.y + a.height) {
+            if (containsPoint(a, mx, my)) {
                 return true;
             }
         }
@@ -700,10 +835,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     public void addNote(final int x, final int y) {
         final Note note = new Note(UUID.randomUUID(), x, y);
         graph.notes.put(note.id, note);
-        final NoteWidget nw = new NoteWidget(note, this);
-        nw.syncTransform(zoom, panX, panY);
-        noteWidgets.put(note.id, nw);
-        child(nw);
+        addNoteWidget(note);
     }
 
     public void removeNote(final UUID noteId) {
@@ -813,10 +945,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     }
 
     public boolean isMouseOverContextMenu(final int mx, final int my) {
-        return contextMenu != null && mx >= contextMenu.getArea().x
-            && mx < contextMenu.getArea().x + contextMenu.getArea().width
-            && my >= contextMenu.getArea().y
-            && my < contextMenu.getArea().y + contextMenu.getArea().height;
+        return contextMenu != null && containsPoint(contextMenu.getArea(), mx, my);
     }
 
     private void openColorPickerFor(final Group group) {
@@ -825,7 +954,12 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
             group.colorOverride = chosenColor;
             rebuildGroupWidgets();
         }, currentColor, false);
-        IPanelHandler.simple(getPanel(), (parent, player) -> picker, true)
+        IPanelHandler
+            .simple(
+                getPanel(),
+                (@SuppressWarnings("unused") final ModularPanel parentPanel,
+                    @SuppressWarnings("unused") final EntityPlayer player) -> picker,
+                true)
             .openPanel();
     }
 
@@ -837,20 +971,8 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
 
     private void showCanvasContextMenu(final int cmx, final int cmy) {
         final List<ContextMenuWidget.MenuItem> items = new ArrayList<>();
-        items.add(new ContextMenuWidget.MenuItem("Add Group", () -> {
-            int gx = Math.round((cmx - panX) / zoom);
-            int gy = Math.round((cmy - panY) / zoom);
-            if (gx < 0) gx = 0;
-            if (gy < 0) gy = 0;
-            addGroup(gx, gy);
-        }));
-        items.add(new ContextMenuWidget.MenuItem("Add Note", () -> {
-            int nx = Math.round((cmx - panX) / zoom);
-            int ny = Math.round((cmy - panY) / zoom);
-            if (nx < 0) nx = 0;
-            if (ny < 0) ny = 0;
-            addNote(nx, ny);
-        }));
+        items.add(new ContextMenuWidget.MenuItem("Add Group", () -> addGroup(toWorldX(cmx), toWorldY(cmy))));
+        items.add(new ContextMenuWidget.MenuItem("Add Note", () -> addNote(toWorldX(cmx), toWorldY(cmy))));
         contextMenuAt(cmx, cmy, items);
     }
 
@@ -862,11 +984,11 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         items.add(
             new ContextMenuWidget.MenuItem(
                 group.clampNodes ? "Disable Clamp" : "Enable Clamp",
-                () -> { group.clampNodes = !group.clampNodes; }));
+                () -> group.clampNodes = !group.clampNodes));
         items.add(
             new ContextMenuWidget.MenuItem(
                 group.autoResize ? "Disable Auto-Resize" : "Enable Auto-Resize",
-                () -> { group.autoResize = !group.autoResize; }));
+                () -> group.autoResize = !group.autoResize));
         items.add(new ContextMenuWidget.MenuItem("Delete Group", () -> removeGroup(group.id)));
         contextMenuAt(cmx, cmy, items);
     }
@@ -879,7 +1001,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
             items.add(
                 new ContextMenuWidget.MenuItem(
                     "Remove from \"" + currentGroup.title + "\"",
-                    () -> { currentGroup.nodeIds.remove(node.id); }));
+                    () -> currentGroup.nodeIds.remove(node.id)));
         }
         final List<Group> otherGroups = new ArrayList<>();
         for (final Group g : graph.getGroups()) {
@@ -992,7 +1114,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
 
     private static void drawPortLabel(String name, final int anchorX, final int centerY, final boolean rightSide,
         final float z) {
-        if (name.length() > PORT_LABEL_MAX) name = name.substring(0, PORT_LABEL_TRUNC) + "\u2026";
+        if (name.length() > PORT_LABEL_MAX) name = name.substring(0, PORT_LABEL_TRUNC) + "…";
         final int tw = Minecraft.getMinecraft().fontRenderer.getStringWidth(name);
         final int fh = Math.round(PORT_FONT_SIZE * z * PORT_FONT_SCALE);
         final int gap = Math.round(PORT_GAP * z);

--- a/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
@@ -146,6 +146,20 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
         size(Math.round(BASE_W * z), Math.round(BASE_H * z));
     }
 
+    int getWorldWidth() {
+        if (handlerRef != null && neiWidget != null) {
+            return neiWidget.w + NEI_PAD_W + NEI_BORDER;
+        }
+        return BASE_W;
+    }
+
+    int getWorldHeight() {
+        if (handlerRef != null && neiWidget != null) {
+            return neiWidget.h + NEI_PAD_H + calcInfoHeight() + computeConfigPanelHeight() + NEI_BORDER;
+        }
+        return BASE_H;
+    }
+
     public void syncTransform(final float zoom, final float panX, final float panY) {
         final int sx = Math.round(node.x * zoom + panX);
         final int sy = Math.round(node.y * zoom + panY);


### PR DESCRIPTION
DISCLAIMER : clankers were used for this, I'm only opening this PR as requested by the maintainer.

This adds pathfinding for the arrows so that they dont overlay or go behind recipe UIs.

BEFORE :
<img width="896" height="789" alt="image" src="https://github.com/user-attachments/assets/1198f965-4456-43ca-9ac6-1b36702899fe" />

AFTER :

<img width="1126" height="887" alt="image" src="https://github.com/user-attachments/assets/7f9cb4b0-5055-4947-ad13-f4a42211bb6d" />
