### PR TITLE
Order's QOL Patches

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -58,4 +58,12 @@ dependencies {
 
     // ILP solver
     implementation('org.ojalgo:ojalgo:47.3.1')
+
+    // Opt-in GTNH pack recipes for the dev client: `./gradlew runClient -PgtnhRecipes`.
+    // Loads the GTNH coremod (dreamcraft) and its transitive mods so NEI shows the pack's
+    // recipe tweaks in dev instead of base GT5U recipes. Off by default to keep plain
+    // runClient light.
+    if (project.hasProperty('gtnhRecipes')) {
+        runtimeOnlyNonPublishable('com.github.GTNewHorizons:NewHorizonsCoreMod:2.9.13:dev')
+    }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -46,7 +46,7 @@ dependencies {
     compileOnly("net.glease:tc4recipelib:1.5.37:dev")
     compileOnly("com.github.GTNewHorizons:ForestryMC:4.11.27:dev")
     compileOnly("ganymedes01.etfuturum:Et-Futurum-Requiem:2.6.45-GTNH:dev")
-    devOnlyNonPublishable("com.github.GTNewHorizons:GT5-Unofficial:5.09.52.613:dev")
+    implementation("com.github.GTNewHorizons:GT5-Unofficial:5.09.52.613:dev")
     runtimeOnlyNonPublishable('com.github.GTNewHorizons:Angelica:2.1.38:dev') { transitive = false }
 
     // Speeds up mod identification and loading in dev
@@ -61,8 +61,7 @@ dependencies {
 
     // Opt-in GTNH pack recipes for the dev client: `./gradlew runClient -PgtnhRecipes`.
     // Loads the GTNH coremod (dreamcraft) and its transitive mods so NEI shows the pack's
-    // recipe tweaks in dev instead of base GT5U recipes. Off by default to keep plain
-    // runClient light.
+    // recipe tweaks in dev instead of base GT5U recipes. Useful for flowchart behavior checking
     if (project.hasProperty('gtnhRecipes')) {
         runtimeOnlyNonPublishable('com.github.GTNewHorizons:NewHorizonsCoreMod:2.9.13:dev')
     }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -60,8 +60,7 @@ dependencies {
     implementation('org.ojalgo:ojalgo:47.3.1')
 
     // Opt-in GTNH pack recipes for the dev client: `./gradlew runClient -PgtnhRecipes`.
-    // Loads the GTNH coremod (dreamcraft) and its transitive mods so NEI shows the pack's
-    // recipe tweaks in dev instead of base GT5U recipes. Useful for flowchart behavior checking
+    // Loads the GTNH coremod (dreamcraft) so NEI shows the pack's recipe tweaks in dev.
     if (project.hasProperty('gtnhRecipes')) {
         runtimeOnlyNonPublishable('com.github.GTNewHorizons:NewHorizonsCoreMod:2.9.13:dev')
     }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -46,7 +46,7 @@ dependencies {
     compileOnly("net.glease:tc4recipelib:1.5.37:dev")
     compileOnly("com.github.GTNewHorizons:ForestryMC:4.11.27:dev")
     compileOnly("ganymedes01.etfuturum:Et-Futurum-Requiem:2.6.45-GTNH:dev")
-    implementation("com.github.GTNewHorizons:GT5-Unofficial:5.09.52.613:dev")
+    devOnlyNonPublishable("com.github.GTNewHorizons:GT5-Unofficial:5.09.52.613:dev")
     runtimeOnlyNonPublishable('com.github.GTNewHorizons:Angelica:2.1.38:dev') { transitive = false }
 
     // Speeds up mod identification and loading in dev

--- a/src/main/java/com/sbancuz/plannh/api/PlanAPI.java
+++ b/src/main/java/com/sbancuz/plannh/api/PlanAPI.java
@@ -21,7 +21,6 @@ import net.minecraft.util.StatCollector;
 import com.sbancuz.plannh.data.flowchart.Graph;
 import com.sbancuz.plannh.data.flowchart.Serializer;
 import com.sbancuz.plannh.data.flowchart.SlotSet;
-import com.sbancuz.plannh.nei.NodeLookupContext;
 
 import codechicken.nei.NEIClientConfig;
 import codechicken.nei.NEIClientUtils;
@@ -33,14 +32,6 @@ public final class PlanAPI {
 
     @Nullable
     private static SlotSet slotSet = null;
-
-    private static final NodeLookupContext LOOKUP_CONTEXT = new NodeLookupContext();
-
-    /** The session's pending NEI lookup origin (see {@link NodeLookupContext}). */
-    @Nonnull
-    public static NodeLookupContext lookupContext() {
-        return LOOKUP_CONTEXT;
-    }
 
     @Nonnull
     public static SlotSet getSlotSet() {

--- a/src/main/java/com/sbancuz/plannh/api/PlanAPI.java
+++ b/src/main/java/com/sbancuz/plannh/api/PlanAPI.java
@@ -21,6 +21,7 @@ import net.minecraft.util.StatCollector;
 import com.sbancuz.plannh.data.flowchart.Graph;
 import com.sbancuz.plannh.data.flowchart.Serializer;
 import com.sbancuz.plannh.data.flowchart.SlotSet;
+import com.sbancuz.plannh.nei.NodeLookupContext;
 
 import codechicken.nei.NEIClientConfig;
 import codechicken.nei.NEIClientUtils;
@@ -32,6 +33,14 @@ public final class PlanAPI {
 
     @Nullable
     private static SlotSet slotSet = null;
+
+    private static final NodeLookupContext LOOKUP_CONTEXT = new NodeLookupContext();
+
+    /** The session's pending NEI lookup origin (see {@link NodeLookupContext}). */
+    @Nonnull
+    public static NodeLookupContext lookupContext() {
+        return LOOKUP_CONTEXT;
+    }
 
     @Nonnull
     public static SlotSet getSlotSet() {

--- a/src/main/java/com/sbancuz/plannh/api/RecipePropertyAPI.java
+++ b/src/main/java/com/sbancuz/plannh/api/RecipePropertyAPI.java
@@ -45,7 +45,6 @@ public final class RecipePropertyAPI {
             s -> 31 * s.getItem()
                 .hashCode() + s.getItemDamage())
         .displayStackProvider(stack -> stack)
-        .lookupMatcher(ItemStack::isItemEqual)
         .colorProvider(IngredientColors::itemColor)
         .pinInputColor(PlannhColors.PIN_INPUT.getColor())
         .pinOutputColor(PlannhColors.PIN_OUTPUT.getColor())
@@ -65,14 +64,9 @@ public final class RecipePropertyAPI {
         .hashCodeExtractor(
             fs -> fs.getFluid()
                 .hashCode())
-        // Guards sit inside the lambdas so GT classes only load if GT is present AND the
+        // Guard sits inside the lambda so GT classes only load if GT is present AND the
         // lambda actually runs (lambda bodies resolve their classes at call time, not here).
         .displayStackProvider(fs -> Compat.GREGTECH.isLoaded ? GTHooks.fluidDisplayStack(fs) : null)
-        .lookupMatcher((fs, lookup) -> {
-            if (!Compat.GREGTECH.isLoaded) return false;
-            final FluidStack lookupFluid = GTHooks.fluidFromDisplayStack(lookup);
-            return lookupFluid != null && lookupFluid.getFluid() == fs.getFluid();
-        })
         .colorProvider(IngredientColors::fluidColor)
         .pinInputColor(PlannhColors.PIN_FLUID_IN.getColor())
         .pinOutputColor(PlannhColors.PIN_FLUID_OUT.getColor())

--- a/src/main/java/com/sbancuz/plannh/api/RecipePropertyAPI.java
+++ b/src/main/java/com/sbancuz/plannh/api/RecipePropertyAPI.java
@@ -14,9 +14,13 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.OreDictionary;
 
+import com.sbancuz.plannh.Compat;
 import com.sbancuz.plannh.data.PropertyProvider;
 import com.sbancuz.plannh.data.RecipeProperty;
 import com.sbancuz.plannh.data.RecipeResource;
+import com.sbancuz.plannh.data.provider.gregtech.GTHooks;
+import com.sbancuz.plannh.gui.IngredientColors;
+import com.sbancuz.plannh.gui.PlannhColors;
 
 public final class RecipePropertyAPI {
 
@@ -40,6 +44,12 @@ public final class RecipePropertyAPI {
         .hashCodeExtractor(
             s -> 31 * s.getItem()
                 .hashCode() + s.getItemDamage())
+        .displayStackProvider(stack -> stack)
+        .lookupMatcher(ItemStack::isItemEqual)
+        .colorProvider(IngredientColors::itemColor)
+        .pinInputColor(PlannhColors.PIN_INPUT.getColor())
+        .pinOutputColor(PlannhColors.PIN_OUTPUT.getColor())
+        .arrowColor(PlannhColors.ARROW_ITEM.getColor())
         .build();
 
     public static final RecipeResource<FluidStack> FLUID = RecipeResource
@@ -55,6 +65,18 @@ public final class RecipePropertyAPI {
         .hashCodeExtractor(
             fs -> fs.getFluid()
                 .hashCode())
+        // Guards sit inside the lambdas so GT classes only load if GT is present AND the
+        // lambda actually runs (lambda bodies resolve their classes at call time, not here).
+        .displayStackProvider(fs -> Compat.GREGTECH.isLoaded ? GTHooks.fluidDisplayStack(fs) : null)
+        .lookupMatcher((fs, lookup) -> {
+            if (!Compat.GREGTECH.isLoaded) return false;
+            final FluidStack lookupFluid = GTHooks.fluidFromDisplayStack(lookup);
+            return lookupFluid != null && lookupFluid.getFluid() == fs.getFluid();
+        })
+        .colorProvider(IngredientColors::fluidColor)
+        .pinInputColor(PlannhColors.PIN_FLUID_IN.getColor())
+        .pinOutputColor(PlannhColors.PIN_FLUID_OUT.getColor())
+        .arrowColor(PlannhColors.ARROW_FLUID.getColor())
         .build();
 
     private static boolean itemsMatch(final ItemStack a, final ItemStack b) {

--- a/src/main/java/com/sbancuz/plannh/api/RecipePropertyAPI.java
+++ b/src/main/java/com/sbancuz/plannh/api/RecipePropertyAPI.java
@@ -10,6 +10,7 @@ import javax.annotation.Nullable;
 
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidContainerRegistry;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.OreDictionary;
@@ -66,7 +67,17 @@ public final class RecipePropertyAPI {
                 .hashCode())
         // Guard sits inside the lambda so GT classes only load if GT is present AND the
         // lambda actually runs (lambda bodies resolve their classes at call time, not here).
-        .displayStackProvider(fs -> Compat.GREGTECH.isLoaded ? GTHooks.fluidDisplayStack(fs) : null)
+        .displayStackProvider(fs -> {
+            if (Compat.GREGTECH.isLoaded) {
+                final ItemStack display = GTHooks.fluidDisplayStack(fs);
+                if (display != null) return display;
+            }
+            // Forge's registry fills only from a full container's worth, so normalize the
+            // amount; null when the fluid has no registered container.
+            return FluidContainerRegistry.fillFluidContainer(
+                new FluidStack(fs.getFluid(), FluidContainerRegistry.BUCKET_VOLUME),
+                FluidContainerRegistry.EMPTY_BUCKET.copy());
+        })
         .colorProvider(IngredientColors::fluidColor)
         .pinInputColor(PlannhColors.PIN_FLUID_IN.getColor())
         .pinOutputColor(PlannhColors.PIN_FLUID_OUT.getColor())

--- a/src/main/java/com/sbancuz/plannh/data/RecipeResource.java
+++ b/src/main/java/com/sbancuz/plannh/data/RecipeResource.java
@@ -3,8 +3,14 @@ package com.sbancuz.plannh.data;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
+import java.util.function.Function;
 import java.util.function.ToIntFunction;
 
+import javax.annotation.Nullable;
+
+import net.minecraft.item.ItemStack;
+
+import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
 @SuperBuilder(builderMethodName = "emptyBuilder")
@@ -19,6 +25,25 @@ public class RecipeResource<T> extends RecipeProperty<T> {
     private final BiPredicate<T, T> connectionChecker = (a, b) -> true;
     @lombok.Builder.Default
     private final ToIntFunction<T> hashCodeExtractor = Objects::hashCode;
+
+    @lombok.Builder.Default
+    private final Function<T, ItemStack> displayStackProvider = (v) -> null;
+    @lombok.Builder.Default
+    private final BiPredicate<T, ItemStack> lookupMatcher = (v, stack) -> false;
+    @lombok.Builder.Default
+    private final ToIntFunction<T> colorProvider = (v) -> -1;
+
+    // Pin/arrow colors used when no per-value color is derivable. Opaque white so a resource
+    // type that declares none still renders visibly instead of vanishing.
+    @Getter
+    @lombok.Builder.Default
+    private final int pinInputColor = 0xFFFFFFFF;
+    @Getter
+    @lombok.Builder.Default
+    private final int pinOutputColor = 0xFFFFFFFF;
+    @Getter
+    @lombok.Builder.Default
+    private final int arrowColor = 0xFFFFFFFF;
 
     @Override
     public String displayName() {
@@ -39,6 +64,22 @@ public class RecipeResource<T> extends RecipeProperty<T> {
 
     public int hashValue(final T value) {
         return hashCodeExtractor.applyAsInt(value);
+    }
+
+    /** The ItemStack recipe viewers (NEI) show for this value; null if it has none. */
+    @Nullable
+    public ItemStack displayStack(final T value) {
+        return displayStackProvider.apply(value);
+    }
+
+    /** Whether an NEI lookup stack refers to this value. */
+    public boolean matchesLookup(final T value, final ItemStack lookup) {
+        return lookupMatcher.test(value, lookup);
+    }
+
+    /** Representative bare-RGB color for this value, or -1 when none is derivable. */
+    public int color(final T value) {
+        return colorProvider.applyAsInt(value);
     }
 
     public static <B> RecipeResourceBuilder<B, ?, ?> builder(final String key, final B defaultValue) {

--- a/src/main/java/com/sbancuz/plannh/data/RecipeResource.java
+++ b/src/main/java/com/sbancuz/plannh/data/RecipeResource.java
@@ -31,8 +31,7 @@ public class RecipeResource<T> extends RecipeProperty<T> {
     @lombok.Builder.Default
     private final ToIntFunction<T> colorProvider = (v) -> -1;
 
-    // Pin/arrow colors used when no per-value color is derivable. Opaque white so a resource
-    // type that declares none still renders visibly instead of vanishing.
+    // Pin/arrow fallback colors; opaque white so a type that declares none stays visible.
     @Getter
     @lombok.Builder.Default
     private final int pinInputColor = 0xFFFFFFFF;

--- a/src/main/java/com/sbancuz/plannh/data/RecipeResource.java
+++ b/src/main/java/com/sbancuz/plannh/data/RecipeResource.java
@@ -29,8 +29,6 @@ public class RecipeResource<T> extends RecipeProperty<T> {
     @lombok.Builder.Default
     private final Function<T, ItemStack> displayStackProvider = (v) -> null;
     @lombok.Builder.Default
-    private final BiPredicate<T, ItemStack> lookupMatcher = (v, stack) -> false;
-    @lombok.Builder.Default
     private final ToIntFunction<T> colorProvider = (v) -> -1;
 
     // Pin/arrow colors used when no per-value color is derivable. Opaque white so a resource
@@ -70,11 +68,6 @@ public class RecipeResource<T> extends RecipeProperty<T> {
     @Nullable
     public ItemStack displayStack(final T value) {
         return displayStackProvider.apply(value);
-    }
-
-    /** Whether an NEI lookup stack refers to this value. */
-    public boolean matchesLookup(final T value, final ItemStack lookup) {
-        return lookupMatcher.test(value, lookup);
     }
 
     /** Representative bare-RGB color for this value, or -1 when none is derivable. */

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/Graph.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/Graph.java
@@ -88,6 +88,13 @@ public class Graph {
     }
 
     public void addEdge(final Edge edge) {
+        // A source-port/target-port pair carries at most one edge: re-wiring it replaces the
+        // existing edge instead of stacking a duplicate.
+        edges.values()
+            .removeIf(
+                e -> e.sourceNodeId.equals(edge.sourceNodeId) && e.sourceOutputIndex == edge.sourceOutputIndex
+                    && e.targetNodeId.equals(edge.targetNodeId)
+                    && e.targetInputIndex == edge.targetInputIndex);
         edges.put(edge.id, edge);
         markDirty();
     }
@@ -97,28 +104,18 @@ public class Graph {
         markDirty();
     }
 
-    public boolean hasIncomingEdge(final UUID nodeId, final int inputIndex) {
-        for (final Edge edge : edges.values()) {
-            if (edge.targetNodeId.equals(nodeId) && edge.targetInputIndex == inputIndex) return true;
-        }
-        return false;
-    }
-
     /**
-     * First input port of {@code dst} that accepts {@code src}'s given output, preferring ports
-     * that nothing feeds yet; -1 when none is compatible. The single auto-wiring policy for both
-     * drop-on-node-body connects and NEI lookup auto-connects.
+     * First input port of {@code dst} that accepts {@code src}'s given output; -1 when none is
+     * compatible. The single auto-wiring rule for both drop-on-node-body connects and NEI
+     * lookup auto-connects.
      */
     public int findCompatibleInput(final Node src, final int srcOutIdx, final Node dst) {
         if (src == dst || srcOutIdx < 0 || srcOutIdx >= src.outputs.size()) return -1;
         final Port<?> out = src.outputs.get(srcOutIdx);
-        int firstCompatible = -1;
         for (int i = 0; i < dst.inputs.size(); i++) {
-            if (!out.canConnect(dst.inputs.get(i))) continue;
-            if (firstCompatible < 0) firstCompatible = i;
-            if (!hasIncomingEdge(dst.id, i)) return i;
+            if (out.canConnect(dst.inputs.get(i))) return i;
         }
-        return firstCompatible;
+        return -1;
     }
 
     public void removeGroup(final UUID id) {

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/Graph.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/Graph.java
@@ -97,6 +97,30 @@ public class Graph {
         markDirty();
     }
 
+    public boolean hasIncomingEdge(final UUID nodeId, final int inputIndex) {
+        for (final Edge edge : edges.values()) {
+            if (edge.targetNodeId.equals(nodeId) && edge.targetInputIndex == inputIndex) return true;
+        }
+        return false;
+    }
+
+    /**
+     * First input port of {@code dst} that accepts {@code src}'s given output, preferring ports
+     * that nothing feeds yet; -1 when none is compatible. The single auto-wiring policy for both
+     * drop-on-node-body connects and NEI lookup auto-connects.
+     */
+    public int findCompatibleInput(final Node src, final int srcOutIdx, final Node dst) {
+        if (src == dst || srcOutIdx < 0 || srcOutIdx >= src.outputs.size()) return -1;
+        final Port<?> out = src.outputs.get(srcOutIdx);
+        int firstCompatible = -1;
+        for (int i = 0; i < dst.inputs.size(); i++) {
+            if (!out.canConnect(dst.inputs.get(i))) continue;
+            if (firstCompatible < 0) firstCompatible = i;
+            if (!hasIncomingEdge(dst.id, i)) return i;
+        }
+        return firstCompatible;
+    }
+
     public void removeGroup(final UUID id) {
         groups.remove(id);
     }

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/Graph.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/Graph.java
@@ -106,8 +106,7 @@ public class Graph {
 
     /**
      * First input port of {@code dst} that accepts {@code src}'s given output; -1 when none is
-     * compatible. The single auto-wiring rule for both drop-on-node-body connects and NEI
-     * lookup auto-connects.
+     * compatible.
      */
     public int findCompatibleInput(final Node src, final int srcOutIdx, final Node dst) {
         if (src == dst || srcOutIdx < 0 || srcOutIdx >= src.outputs.size()) return -1;

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/Port.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/Port.java
@@ -38,11 +38,6 @@ public class Port<T> {
         return type.displayStack(value);
     }
 
-    /** Whether an NEI lookup stack refers to this port's ingredient. */
-    public boolean matchesLookup(final ItemStack lookup) {
-        return type.matchesLookup(value, lookup);
-    }
-
     /** Pin color for this port's ingredient; the type's pin color when none is derivable. */
     public int getPinColor(final boolean input) {
         return colorOr(input ? type.getPinInputColor() : type.getPinOutputColor());

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/Port.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/Port.java
@@ -1,5 +1,10 @@
 package com.sbancuz.plannh.data.flowchart;
 
+import javax.annotation.Nullable;
+
+import net.minecraft.item.ItemStack;
+
+import com.cleanroommc.modularui.utils.Color;
 import com.sbancuz.plannh.data.RecipeResource;
 
 import lombok.Getter;
@@ -25,6 +30,34 @@ public class Port<T> {
 
     public String getDisplayName() {
         return type.formatDisplayName(value);
+    }
+
+    /** The ItemStack recipe viewers (NEI) show for this port's ingredient; null if none. */
+    @Nullable
+    public ItemStack getDisplayStack() {
+        return type.displayStack(value);
+    }
+
+    /** Whether an NEI lookup stack refers to this port's ingredient. */
+    public boolean matchesLookup(final ItemStack lookup) {
+        return type.matchesLookup(value, lookup);
+    }
+
+    /** Pin color for this port's ingredient; the type's pin color when none is derivable. */
+    public int getPinColor(final boolean input) {
+        return colorOr(input ? type.getPinInputColor() : type.getPinOutputColor());
+    }
+
+    /** Edge-arrow color for this port's ingredient; the type's arrow color as fallback. */
+    public int getArrowColor() {
+        return colorOr(type.getArrowColor());
+    }
+
+    /** Representative color for this port's ingredient; {@code fallback}'s alpha is kept. */
+    private int colorOr(final int fallback) {
+        final int rgb = type.color(value);
+        if (rgb == -1) return fallback;
+        return Color.withAlpha(rgb, Color.getAlpha(fallback));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/sbancuz/plannh/data/provider/gregtech/GTHooks.java
+++ b/src/main/java/com/sbancuz/plannh/data/provider/gregtech/GTHooks.java
@@ -21,12 +21,6 @@ public final class GTHooks {
         return GTUtility.getFluidDisplayStack(fluidStack, false);
     }
 
-    /** Reverses {@link #fluidDisplayStack}; null if the stack is not a fluid display item. */
-    @Nullable
-    public static FluidStack fluidFromDisplayStack(final ItemStack stack) {
-        return GTUtility.getFluidFromDisplayStack(stack);
-    }
-
     /**
      * GT material color for MetaGeneratedItems (their renderer applies it, so the item icon API
      * lies about their color); white when the stack has none.

--- a/src/main/java/com/sbancuz/plannh/data/provider/gregtech/GTHooks.java
+++ b/src/main/java/com/sbancuz/plannh/data/provider/gregtech/GTHooks.java
@@ -1,0 +1,41 @@
+package com.sbancuz.plannh.data.provider.gregtech;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+
+import gregtech.api.items.MetaGeneratedItem;
+import gregtech.api.util.GTUtility;
+
+/** GT class references, isolated. Only call behind {@code Compat.GREGTECH.isLoaded}. */
+public final class GTHooks {
+
+    private GTHooks() {}
+
+    /** The display item NEI shows for a fluid - the stack R/U lookups and edges operate on. */
+    @Nullable
+    public static ItemStack fluidDisplayStack(final FluidStack fluidStack) {
+        return GTUtility.getFluidDisplayStack(fluidStack, false);
+    }
+
+    /** Reverses {@link #fluidDisplayStack}; null if the stack is not a fluid display item. */
+    @Nullable
+    public static FluidStack fluidFromDisplayStack(final ItemStack stack) {
+        return GTUtility.getFluidFromDisplayStack(stack);
+    }
+
+    /**
+     * GT material color for MetaGeneratedItems (their renderer applies it, so the item icon API
+     * lies about their color); white when the stack has none.
+     */
+    public static int materialTint(final ItemStack stack) {
+        if (stack.getItem() instanceof final MetaGeneratedItem gtItem) {
+            final short[] rgba = gtItem.getRGBa(stack);
+            if (rgba != null && rgba.length >= 3) {
+                return (rgba[0] & 0xFF) << 16 | (rgba[1] & 0xFF) << 8 | (rgba[2] & 0xFF);
+            }
+        }
+        return 0xFFFFFF;
+    }
+}

--- a/src/main/java/com/sbancuz/plannh/data/provider/gregtech/GTHooks.java
+++ b/src/main/java/com/sbancuz/plannh/data/provider/gregtech/GTHooks.java
@@ -5,6 +5,8 @@ import javax.annotation.Nullable;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
+import com.cleanroommc.modularui.utils.Color;
+
 import gregtech.api.items.MetaGeneratedItem;
 import gregtech.api.util.GTUtility;
 
@@ -33,7 +35,7 @@ public final class GTHooks {
         if (stack.getItem() instanceof final MetaGeneratedItem gtItem) {
             final short[] rgba = gtItem.getRGBa(stack);
             if (rgba != null && rgba.length >= 3) {
-                return (rgba[0] & 0xFF) << 16 | (rgba[1] & 0xFF) << 8 | (rgba[2] & 0xFF);
+                return Color.rgb(rgba[0], rgba[1], rgba[2]) & 0xFFFFFF;
             }
         }
         return 0xFFFFFF;

--- a/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
@@ -44,7 +44,6 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
 
     private static final int ARROW_COLOR_ITEM = PlannhColors.ARROW_ITEM.getColor();
     private static final int ARROW_COLOR_FLUID = PlannhColors.ARROW_FLUID.getColor();
-    private static final int EDGE_OUTLINE = 0xF00A0A0A;
     private static final int EDGE_OUTLINE_EXTRA = 3;
     private static final int PREVIEW_COLOR = PlannhColors.PREVIEW_HIGHLIGHT.getColor();
     private static final int CLAMP_MARGIN = 4;
@@ -490,9 +489,11 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         sx[n - 1] = Math.round(x2 - as);
 
         final float thickness = Math.max(LINE_THICK_MIN, LINE_THICK_BASE * graph.getZoom());
-        // Dark underlay so the colored line stays readable over any world background.
-        drawLineStrip(sx, sy, EDGE_OUTLINE, thickness + EDGE_OUTLINE_EXTRA);
-        drawArrowHead(x2, y2, sx[n - 1], as * ARROW_HB_RATIO + EDGE_OUTLINE_EXTRA / 2f, EDGE_OUTLINE);
+        // Contrast underlay (light under dark colors, dark under light ones) so the colored
+        // line stays readable over any world background.
+        final int outline = IngredientColors.outlineFor(color);
+        drawLineStrip(sx, sy, outline, thickness + EDGE_OUTLINE_EXTRA);
+        drawArrowHead(x2, y2, sx[n - 1], as * ARROW_HB_RATIO + EDGE_OUTLINE_EXTRA / 2f, outline);
         drawLineStrip(sx, sy, color, thickness);
         drawArrowHead(x2, y2, sx[n - 1], as * ARROW_HB_RATIO, color);
     }
@@ -501,8 +502,9 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         final float as = Math.max(ARROW_MIN_SIZE, ARROW_SIZE * graph.getZoom());
         final int ex = Math.round(x2 - as);
         final float thickness = Math.max(LINE_THICK_MIN, LINE_THICK_BASE * graph.getZoom());
-        drawOrthogonalLine(x1, y1, x2, y2, ex, EDGE_OUTLINE, thickness + EDGE_OUTLINE_EXTRA);
-        drawArrowHead(x2, y2, ex, as * ARROW_HB_RATIO + EDGE_OUTLINE_EXTRA / 2f, EDGE_OUTLINE);
+        final int outline = IngredientColors.outlineFor(color);
+        drawOrthogonalLine(x1, y1, x2, y2, ex, outline, thickness + EDGE_OUTLINE_EXTRA);
+        drawArrowHead(x2, y2, ex, as * ARROW_HB_RATIO + EDGE_OUTLINE_EXTRA / 2f, outline);
         drawOrthogonalLine(x1, y1, x2, y2, ex, color, thickness);
         drawArrowHead(x2, y2, ex, as * ARROW_HB_RATIO, color);
     }

--- a/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
@@ -6,8 +6,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import net.minecraft.client.Minecraft;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.opengl.GL11;
@@ -50,9 +48,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     private static final int NODE_W_ESTIMATE = 120;
     private static final int NODE_H_ESTIMATE = 80;
     private static final int HEADER_OFFSET = 24;
-    private static final int PORT_S = 8;
     private static final int PORT_HALF = 4;
-    private static final int PORT_GAP = 6;
     private static final int PORT_SPACING = 18;
     private static final int PORT_ORIGIN = 10;
     private static final int MIN_GRID_SPACING = 4;
@@ -62,11 +58,6 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     private static final int LINE_THICK_MIN = 1;
     private static final float ARROW_HB_RATIO = 0.35f;
     private static final int EDGE_MARGIN_BASE = 4;
-    private static final int PORT_LABEL_MAX = 20;
-    private static final int PORT_LABEL_TRUNC = 19;
-    private static final int PORT_FONT_SIZE = 9;
-    private static final float PORT_FONT_SCALE = 0.9f;
-    private static final int PORT_LABEL_PAD = 2;
 
     private static final int GROUP_FIT_PAD = 12;
     private static final float ZOOM_STEP = 0.15f;
@@ -290,21 +281,13 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         // TODO add toggle for grid
         drawGrid(aw, ah);
 
-        // Arrows before node widgets: nodes cover arrows by paint order, which lets the nodes
-        // keep a z below 300 so NEI tooltips (drawn at z=300) render above them.
-        drawArrows();
-
         super.draw(context, widgetTheme);
 
-        // Interactive aids above node bodies (which reach ~z 250 with their item rendering)
-        // but still under NEI tooltips at z 300.
-        GL11.glPushMatrix();
-        GL11.glTranslatef(0, 0, 280);
+        drawArrows();
+
         if (creatingEdge) {
             drawPreviewLine();
         }
-        drawHoveredPortLabels();
-        GL11.glPopMatrix();
     }
 
     private void drawGrid(final int w, final int h) {
@@ -989,81 +972,9 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
          */
     }
 
-    // ── Hovered port labels ──
-
-    private void drawHoveredPortLabels() {
-        final int mouseX = getContext().getMouseX();
-        final int mouseY = getContext().getMouseY();
-        final int ps = Math.max(1, Math.round(PORT_S * graph.getZoom()));
-        final int half = Math.round(PORT_HALF * graph.getZoom());
-
-        for (final RecipeNodeWidget w : nodeWidgets.values()) {
-            final Node node = w.getNode();
-            final int widgetX = widgetX(w);
-            final int widgetY = widgetY(w);
-            final int widgetWidth = Math.round(w.getArea().width * graph.getZoom());
-
-            if (tryPortLabel(
-                mouseX,
-                mouseY,
-                graph.getZoom(),
-                ps,
-                half,
-                widgetX,
-                widgetY,
-                widgetWidth,
-                node.outputs,
-                true)) return;
-            if (tryPortLabel(
-                mouseX,
-                mouseY,
-                graph.getZoom(),
-                ps,
-                half,
-                widgetX,
-                widgetY,
-                widgetWidth,
-                node.inputs,
-                false)) return;
-        }
-    }
-
-    private boolean tryPortLabel(final int mouseX, final int mouseY, final float zoom, final int ps, final int half,
-        final int widgetX, final int widgetY, final int widgetWidth, final List<Port<?>> ports,
-        final boolean rightSide) {
-        for (int i = 0; i < ports.size(); i++) {
-            final int px = rightSide ? widgetX + widgetWidth - ps : widgetX;
-            final int pcY = widgetY + portY(i);
-            final int py = pcY - half;
-            if (mouseX >= px && mouseX < px + ps && mouseY >= py && mouseY < py + ps) {
-                final String label = portLabel(ports.get(i));
-                if (label != null) {
-                    drawPortLabel(label, rightSide ? widgetX + widgetWidth : widgetX, pcY, rightSide, zoom);
-                }
-                return true;
-            }
-        }
-        return false;
-    }
-
-    @Nullable
-    private static String portLabel(final Port port) {
-        final String name = port.getDisplayName();
-        return name.isEmpty() ? null : name;
-    }
-
-    private static void drawPortLabel(String name, final int anchorX, final int centerY, final boolean rightSide,
-        final float z) {
-        if (name.length() > PORT_LABEL_MAX) name = name.substring(0, PORT_LABEL_TRUNC) + "…";
-        final int tw = Minecraft.getMinecraft().fontRenderer.getStringWidth(name);
-        final int fh = Math.round(PORT_FONT_SIZE * z * PORT_FONT_SCALE);
-        final int gap = Math.round(PORT_GAP * z);
-        final int labelX = rightSide ? anchorX + gap : anchorX - tw - gap;
-        final int labelY = centerY - fh / 2;
-        final int pad = Math.round(PORT_LABEL_PAD * z);
-        GuiDraw.drawRect(labelX - pad, labelY - pad, tw + pad * 2, fh + pad * 2, PlannhColors.PORT_LABEL_BG.getColor());
-        GuiDraw.drawText(name, labelX, labelY, z * 0.9f, PlannhColors.TEXT_WHITE.getColor(), false);
-    }
+    // Port-anchored name labels used to be drawn here on pin hover; they were painted inside
+    // the canvas viewport and therefore buried under adjacent nodes. The mouse-anchored full
+    // tooltip (FlowchartScreen.drawHoveredIngredientTooltip) replaced them.
 
     @Override
     public void transformChildren(IViewportStack stack) {

--- a/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
@@ -735,7 +735,10 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         // menuOpen = false;
 
         float delta = direction == UpOrDown.UP ? ZOOM_STEP : -ZOOM_STEP;
-        delta *= Math.max(1, Math.abs(amount));
+        // Real LWJGL2 (dev client, vanilla installs) reports the wheel in multiples of +-120 per
+        // notch, while lwjgl3ify (all modern GTNH packs) reports notch counts directly.
+        final int magnitude = Math.abs(amount);
+        delta *= Math.max(1, magnitude >= 120 ? magnitude / 120 : magnitude);
         final float oldZoom = graph.getZoom();
         graph.setZoom(Math.clamp(graph.getZoom() + delta, ZOOM_MIN, ZOOM_MAX));
         final float ratio = graph.getZoom() / oldZoom;

--- a/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
@@ -120,7 +120,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         if (w != null) remove(w);
     }
 
-    public void setPendingLookup(final NodeLookupContext lookup) {
+    public void setPendingLookup(@Nullable final NodeLookupContext lookup) {
         pendingLookup = lookup;
     }
 
@@ -336,6 +336,11 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         final int ah = getArea().height;
         if (aw <= 0 || ah <= 0) return;
 
+        // MUI2 calls draw() before preDraw(), so the viewport stencil that clips the node
+        // widgets does not exist yet: clip explicitly, or world-space edges and the drag
+        // preview paint outside the canvas.
+        Stencil.applyAtZero(getArea(), context);
+
         // TODO add toggle for grid
         drawGrid(aw, ah);
 
@@ -346,6 +351,8 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         if (creatingEdge) {
             drawPreviewLine();
         }
+
+        Stencil.remove();
     }
 
     private void drawGrid(final int w, final int h) {

--- a/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
@@ -767,8 +767,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         // menuOpen = false;
 
         float delta = direction == UpOrDown.UP ? ZOOM_STEP : -ZOOM_STEP;
-        // Real LWJGL2 (dev client, vanilla installs) reports the wheel in multiples of +-120 per
-        // notch, while lwjgl3ify (all modern GTNH packs) reports notch counts directly.
+        // Normalize LWJGL2-style +-120-per-notch wheel deltas to notch counts.
         final int magnitude = Math.abs(amount);
         delta *= Math.max(1, magnitude >= 120 ? magnitude / 120 : magnitude);
         final float oldZoom = graph.getZoom();

--- a/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
@@ -442,14 +442,11 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
             if (srcWidget == null || dstWidget == null) continue;
 
             final Node srcNode = graph.nodes.get(edge.sourceNodeId);
-            final boolean isFluid = srcNode != null && edge.sourceOutputIndex >= 0
-                && edge.sourceOutputIndex < srcNode.outputs.size()
-                && srcNode.outputs.get(edge.sourceOutputIndex)
-                    .getType() == RecipePropertyAPI.FLUID;
+            final int color = edgeColor(srcNode, edge.sourceOutputIndex);
 
             final List<int[]> route = edgeRoutes.get(edge.id);
             if (route != null && route.size() >= 2) {
-                drawRoutedArrow(route, isFluid);
+                drawRoutedArrow(route, color);
                 continue;
             }
 
@@ -458,14 +455,24 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
             final int dstX = widgetX(dstWidget);
             final int dstY = widgetY(dstWidget) + portY(edge.targetInputIndex);
 
-            drawArrow(srcX, srcY, dstX, dstY, isFluid);
+            drawArrow(srcX, srcY, dstX, dstY, color);
         }
+    }
+
+    /** Edge color follows the ingredient flowing through it; type color as fallback. */
+    private static int edgeColor(@Nullable final Node srcNode, final int outputIndex) {
+        if (srcNode == null || outputIndex < 0 || outputIndex >= srcNode.outputs.size()) {
+            return ARROW_COLOR_ITEM;
+        }
+        final Port<?> port = srcNode.outputs.get(outputIndex);
+        final int fallback = port.getType() == RecipePropertyAPI.FLUID ? ARROW_COLOR_FLUID : ARROW_COLOR_ITEM;
+        return IngredientColors.of(port, fallback);
     }
 
     /**
      * Draws a multi-segment orthogonal arrow from cached world-space waypoints.
      */
-    private void drawRoutedArrow(final List<int[]> route, final boolean fluid) {
+    private void drawRoutedArrow(final List<int[]> route, final int color) {
         final int n = route.size();
         final int[] sx = new int[n];
         final int[] sy = new int[n];
@@ -475,7 +482,6 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         }
 
         final float as = Math.max(ARROW_MIN_SIZE, ARROW_SIZE * graph.getZoom());
-        final int color = fluid ? ARROW_COLOR_FLUID : ARROW_COLOR_ITEM;
         final int x2 = sx[n - 1];
         final int y2 = sy[n - 1];
         // Stop the line at the arrow base so it does not poke through the head (last segment is horizontal).
@@ -485,10 +491,9 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         drawArrowHead(x2, y2, sx[n - 1], as * ARROW_HB_RATIO, color);
     }
 
-    private void drawArrow(final int x1, final int y1, final int x2, final int y2, final boolean fluid) {
+    private void drawArrow(final int x1, final int y1, final int x2, final int y2, final int color) {
         final float as = Math.max(ARROW_MIN_SIZE, ARROW_SIZE * graph.getZoom());
         final int ex = Math.round(x2 - as);
-        final int color = fluid ? ARROW_COLOR_FLUID : ARROW_COLOR_ITEM;
         drawOrthogonalLine(x1, y1, x2, y2, ex, color, Math.max(LINE_THICK_MIN, LINE_THICK_BASE * graph.getZoom()));
 
         drawArrowHead(x2, y2, ex, as * ARROW_HB_RATIO, color);
@@ -719,7 +724,14 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
                 if (widget == srcWidget) continue;
                 final int localMx = worldDragMx - Math.round(widget.getNode().x);
                 final int localMy = worldDragMy - Math.round(widget.getNode().y);
-                final int port = widget.getInputPortAt(localMx, localMy);
+                int port = widget.getInputPortAt(localMx, localMy);
+                if (port < 0 && localMx >= 0
+                    && localMx < widget.getWorldWidth()
+                    && localMy >= 0
+                    && localMy < widget.getWorldHeight()) {
+                    // Dropped on the node body: wire into a matching input automatically.
+                    port = findCompatibleInputPort(srcWidget.getNode(), edgeSourcePortIndex, widget.getNode());
+                }
                 if (port >= 0 && canConnect(srcWidget.getNode(), edgeSourcePortIndex, widget.getNode(), port)) {
                     edgeHoverNodeId = widget.getNode().id;
                     edgeHoverPortIndex = port;
@@ -727,6 +739,27 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
                 }
             }
         }
+    }
+
+    /**
+     * First input port of {@code dstNode} that accepts the dragged ingredient, preferring ports
+     * that nothing feeds yet.
+     */
+    private int findCompatibleInputPort(final Node srcNode, final int srcOutIdx, final Node dstNode) {
+        int firstCompatible = -1;
+        for (int i = 0; i < dstNode.inputs.size(); i++) {
+            if (!canConnect(srcNode, srcOutIdx, dstNode, i)) continue;
+            if (firstCompatible < 0) firstCompatible = i;
+            if (!hasIncomingEdge(dstNode.id, i)) return i;
+        }
+        return firstCompatible;
+    }
+
+    private boolean hasIncomingEdge(final UUID nodeId, final int inputIndex) {
+        for (final Edge edge : graph.getEdges()) {
+            if (edge.targetNodeId.equals(nodeId) && edge.targetInputIndex == inputIndex) return true;
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
@@ -44,6 +44,8 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
 
     private static final int ARROW_COLOR_ITEM = PlannhColors.ARROW_ITEM.getColor();
     private static final int ARROW_COLOR_FLUID = PlannhColors.ARROW_FLUID.getColor();
+    private static final int EDGE_OUTLINE = 0xE0141414;
+    private static final int EDGE_OUTLINE_EXTRA = 2;
     private static final int PREVIEW_COLOR = PlannhColors.PREVIEW_HIGHLIGHT.getColor();
     private static final int CLAMP_MARGIN = 4;
     private static final int NODE_W_ESTIMATE = 120;
@@ -487,15 +489,21 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         // Stop the line at the arrow base so it does not poke through the head (last segment is horizontal).
         sx[n - 1] = Math.round(x2 - as);
 
-        drawLineStrip(sx, sy, color, Math.max(LINE_THICK_MIN, LINE_THICK_BASE * graph.getZoom()));
+        final float thickness = Math.max(LINE_THICK_MIN, LINE_THICK_BASE * graph.getZoom());
+        // Dark underlay so the colored line stays readable over any world background.
+        drawLineStrip(sx, sy, EDGE_OUTLINE, thickness + EDGE_OUTLINE_EXTRA);
+        drawArrowHead(x2, y2, sx[n - 1], as * ARROW_HB_RATIO + EDGE_OUTLINE_EXTRA / 2f, EDGE_OUTLINE);
+        drawLineStrip(sx, sy, color, thickness);
         drawArrowHead(x2, y2, sx[n - 1], as * ARROW_HB_RATIO, color);
     }
 
     private void drawArrow(final int x1, final int y1, final int x2, final int y2, final int color) {
         final float as = Math.max(ARROW_MIN_SIZE, ARROW_SIZE * graph.getZoom());
         final int ex = Math.round(x2 - as);
-        drawOrthogonalLine(x1, y1, x2, y2, ex, color, Math.max(LINE_THICK_MIN, LINE_THICK_BASE * graph.getZoom()));
-
+        final float thickness = Math.max(LINE_THICK_MIN, LINE_THICK_BASE * graph.getZoom());
+        drawOrthogonalLine(x1, y1, x2, y2, ex, EDGE_OUTLINE, thickness + EDGE_OUTLINE_EXTRA);
+        drawArrowHead(x2, y2, ex, as * ARROW_HB_RATIO + EDGE_OUTLINE_EXTRA / 2f, EDGE_OUTLINE);
+        drawOrthogonalLine(x1, y1, x2, y2, ex, color, thickness);
         drawArrowHead(x2, y2, ex, as * ARROW_HB_RATIO, color);
     }
 

--- a/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
@@ -133,15 +133,10 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     }
 
     /**
-     * Positions an auto-wired node beside its lookup origin: nodes feeding the origin sit to its
-     * left, nodes fed by it to its right, in the first slot down the column that no existing
-     * node occupies. Each successive slot also staggers outward horizontally so the wired edges
-     * run in distinct vertical channels instead of stacking on one line, and every slot carries
-     * a cumulative half-port vertical nudge so port pins (and the horizontal edge runs leaving
-     * them) sit between the origin's port lines rather than on them. The added node's widget
-     * does not exist yet (rebuild happens after placement), so the origin's dimensions (machine
-     * nodes are similarly sized) stand in for its own - and the overlap scan naturally never
-     * sees it.
+     * Positions an auto-wired node beside its lookup origin: producers left, consumers right,
+     * in the first free slot down the column. Slots stagger outward and carry a half-port
+     * vertical nudge so parallel edges and port pins don't overlap. The added node's widget
+     * does not exist yet, so the origin's dimensions stand in for its own.
      */
     public void placeBesideOrigin(final Node added, final Node origin, final boolean addedFeedsOrigin) {
         final RecipeNodeWidget originWidget = nodeWidgets.get(origin.id);
@@ -542,8 +537,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         sx[n - 1] = Math.round(x2 - as);
 
         final float thickness = Math.max(LINE_THICK_MIN, LINE_THICK_BASE * graph.getZoom());
-        // Contrast underlay (light under dark colors, dark under light ones) so the colored
-        // line stays readable over any world background.
+        // Contrast underlay so the colored line stays readable over any world background.
         final int outline = IngredientColors.outlineFor(color);
         drawLineStrip(sx, sy, outline, thickness + EDGE_OUTLINE_EXTRA);
         drawArrowHead(x2, y2, sx[n - 1], as * ARROW_HB_RATIO + EDGE_OUTLINE_EXTRA / 2f, outline);
@@ -1013,10 +1007,6 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
          * contextMenuAt(cmx, cmy, items);
          */
     }
-
-    // Port-anchored name labels used to be drawn here on pin hover; they were painted inside
-    // the canvas viewport and therefore buried under adjacent nodes. The mouse-anchored full
-    // tooltip (FlowchartScreen.drawHoveredIngredientTooltip) replaced them.
 
     @Override
     public void transformChildren(IViewportStack stack) {

--- a/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
@@ -290,15 +290,21 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         // TODO add toggle for grid
         drawGrid(aw, ah);
 
-        super.draw(context, widgetTheme);
-
+        // Arrows before node widgets: nodes cover arrows by paint order, which lets the nodes
+        // keep a z below 300 so NEI tooltips (drawn at z=300) render above them.
         drawArrows();
 
+        super.draw(context, widgetTheme);
+
+        // Interactive aids above node bodies (which reach ~z 250 with their item rendering)
+        // but still under NEI tooltips at z 300.
+        GL11.glPushMatrix();
+        GL11.glTranslatef(0, 0, 280);
         if (creatingEdge) {
             drawPreviewLine();
         }
-
         drawHoveredPortLabels();
+        GL11.glPopMatrix();
     }
 
     private void drawGrid(final int w, final int h) {

--- a/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
@@ -44,8 +44,8 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
 
     private static final int ARROW_COLOR_ITEM = PlannhColors.ARROW_ITEM.getColor();
     private static final int ARROW_COLOR_FLUID = PlannhColors.ARROW_FLUID.getColor();
-    private static final int EDGE_OUTLINE = 0xE0141414;
-    private static final int EDGE_OUTLINE_EXTRA = 2;
+    private static final int EDGE_OUTLINE = 0xF00A0A0A;
+    private static final int EDGE_OUTLINE_EXTRA = 3;
     private static final int PREVIEW_COLOR = PlannhColors.PREVIEW_HIGHLIGHT.getColor();
     private static final int CLAMP_MARGIN = 4;
     private static final int NODE_W_ESTIMATE = 120;

--- a/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
@@ -25,13 +25,12 @@ import com.cleanroommc.modularui.utils.Platform;
 import com.cleanroommc.modularui.widget.ParentWidget;
 import com.cleanroommc.modularui.widget.sizer.Area;
 import com.cleanroommc.modularui.widgets.menu.Menu;
-import com.sbancuz.plannh.api.RecipePropertyAPI;
 import com.sbancuz.plannh.data.flowchart.Edge;
 import com.sbancuz.plannh.data.flowchart.Graph;
 import com.sbancuz.plannh.data.flowchart.Group;
 import com.sbancuz.plannh.data.flowchart.Node;
 import com.sbancuz.plannh.data.flowchart.Note;
-import com.sbancuz.plannh.data.flowchart.Port;
+import com.sbancuz.plannh.nei.NodeLookupContext;
 
 import lombok.Getter;
 
@@ -41,12 +40,14 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     private static final int GRID_MAJOR = 5;
 
     private static final int ARROW_COLOR_ITEM = PlannhColors.ARROW_ITEM.getColor();
-    private static final int ARROW_COLOR_FLUID = PlannhColors.ARROW_FLUID.getColor();
     private static final int EDGE_OUTLINE_EXTRA = 3;
     private static final int PREVIEW_COLOR = PlannhColors.PREVIEW_HIGHLIGHT.getColor();
     private static final int CLAMP_MARGIN = 4;
     private static final int NODE_W_ESTIMATE = 120;
     private static final int NODE_H_ESTIMATE = 80;
+    private static final int AUTO_PLACE_GAP_X = 80;
+    private static final int AUTO_PLACE_GAP_Y = 30;
+    private static final int AUTO_PLACE_STAGGER = 20;
     private static final int HEADER_OFFSET = 24;
     private static final int PORT_HALF = 4;
     private static final int PORT_SPACING = 18;
@@ -98,6 +99,10 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     private final Map<UUID, List<int[]>> edgeRoutes = new HashMap<>();
     private long routeSignature = Long.MIN_VALUE;
 
+    /** The pending NEI lookup origin, if the last R/U lookup started on one of our nodes. */
+    @Nullable
+    private NodeLookupContext pendingLookup;
+
     public CanvasWidget(final Graph graph, Menu<?> menu) {
         this.graph = graph;
         full();
@@ -113,6 +118,59 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         graph.removeNode(nodeId);
         final RecipeNodeWidget w = nodeWidgets.remove(nodeId);
         if (w != null) remove(w);
+    }
+
+    public void setPendingLookup(final NodeLookupContext lookup) {
+        pendingLookup = lookup;
+    }
+
+    /** Returns and clears the pending lookup: it wires at most one added recipe. */
+    @Nullable
+    public NodeLookupContext consumePendingLookup() {
+        final NodeLookupContext result = pendingLookup;
+        pendingLookup = null;
+        return result;
+    }
+
+    /**
+     * Positions an auto-wired node beside its lookup origin: nodes feeding the origin sit to its
+     * left, nodes fed by it to its right, in the first slot down the column that no existing
+     * node occupies. Each successive slot also staggers outward horizontally so the wired edges
+     * run in distinct vertical channels instead of stacking on one line, and every slot carries
+     * a cumulative half-port vertical nudge so port pins (and the horizontal edge runs leaving
+     * them) sit between the origin's port lines rather than on them. The added node's widget
+     * does not exist yet (rebuild happens after placement), so the origin's dimensions (machine
+     * nodes are similarly sized) stand in for its own - and the overlap scan naturally never
+     * sees it.
+     */
+    public void placeBesideOrigin(final Node added, final Node origin, final boolean addedFeedsOrigin) {
+        final RecipeNodeWidget originWidget = nodeWidgets.get(origin.id);
+        final int originW = originWidget != null ? originWidget.getWorldWidth() : NODE_W_ESTIMATE;
+        final int originH = originWidget != null ? originWidget.getWorldHeight() : NODE_H_ESTIMATE;
+        final int baseX = Math
+            .round(addedFeedsOrigin ? origin.x - originW - AUTO_PLACE_GAP_X : origin.x + originW + AUTO_PLACE_GAP_X);
+        final int baseY = Math.round(origin.y);
+        int x;
+        int y;
+        int slot = 0;
+        do {
+            final int stagger = slot * AUTO_PLACE_STAGGER;
+            x = addedFeedsOrigin ? baseX - stagger : baseX + stagger;
+            y = baseY + slot * (originH + AUTO_PLACE_GAP_Y) + (slot + 1) * (PORT_SPACING / 2);
+            slot++;
+        } while (overlapsAnyNode(x, y, originW, originH));
+        added.x = x;
+        added.y = y;
+    }
+
+    private boolean overlapsAnyNode(final int x, final int y, final int w, final int h) {
+        for (final RecipeNodeWidget widget : nodeWidgets.values()) {
+            final Node n = widget.getNode();
+            if (x < n.x + widget.getWorldWidth() && n.x < x + w && y < n.y + widget.getWorldHeight() && n.y < y + h) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public void setGraph(final Graph newGraph) {
@@ -454,9 +512,8 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         if (srcNode == null || outputIndex < 0 || outputIndex >= srcNode.outputs.size()) {
             return ARROW_COLOR_ITEM;
         }
-        final Port<?> port = srcNode.outputs.get(outputIndex);
-        final int fallback = port.getType() == RecipePropertyAPI.FLUID ? ARROW_COLOR_FLUID : ARROW_COLOR_ITEM;
-        return IngredientColors.of(port, fallback);
+        return srcNode.outputs.get(outputIndex)
+            .getArrowColor();
     }
 
     /**
@@ -729,7 +786,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
                     && localMy >= 0
                     && localMy < widget.getWorldHeight()) {
                     // Dropped on the node body: wire into a matching input automatically.
-                    port = findCompatibleInputPort(srcWidget.getNode(), edgeSourcePortIndex, widget.getNode());
+                    port = graph.findCompatibleInput(srcWidget.getNode(), edgeSourcePortIndex, widget.getNode());
                 }
                 if (port >= 0 && canConnect(srcWidget.getNode(), edgeSourcePortIndex, widget.getNode(), port)) {
                     edgeHoverNodeId = widget.getNode().id;
@@ -738,27 +795,6 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
                 }
             }
         }
-    }
-
-    /**
-     * First input port of {@code dstNode} that accepts the dragged ingredient, preferring ports
-     * that nothing feeds yet.
-     */
-    private int findCompatibleInputPort(final Node srcNode, final int srcOutIdx, final Node dstNode) {
-        int firstCompatible = -1;
-        for (int i = 0; i < dstNode.inputs.size(); i++) {
-            if (!canConnect(srcNode, srcOutIdx, dstNode, i)) continue;
-            if (firstCompatible < 0) firstCompatible = i;
-            if (!hasIncomingEdge(dstNode.id, i)) return i;
-        }
-        return firstCompatible;
-    }
-
-    private boolean hasIncomingEdge(final UUID nodeId, final int inputIndex) {
-        for (final Edge edge : graph.getEdges()) {
-            if (edge.targetNodeId.equals(nodeId) && edge.targetInputIndex == inputIndex) return true;
-        }
-        return false;
     }
 
     @Override

--- a/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
+++ b/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
@@ -5,13 +5,17 @@ import java.util.List;
 import javax.annotation.Nonnull;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.StatCollector;
+
+import org.lwjgl.opengl.GL11;
 
 import com.cleanroommc.modularui.api.drawable.IKey;
 import com.cleanroommc.modularui.api.widget.Interactable;
 import com.cleanroommc.modularui.drawable.GuiDraw;
 import com.cleanroommc.modularui.drawable.Rectangle;
+import com.cleanroommc.modularui.integration.recipeviewer.RecipeViewerIngredientProvider;
 import com.cleanroommc.modularui.screen.ModularPanel;
 import com.cleanroommc.modularui.screen.ModularScreen;
 import com.cleanroommc.modularui.screen.UISettings;
@@ -235,6 +239,32 @@ public class FlowchartScreen extends ModularScreen {
     public void onClose() {
         PlanAPI.save();
         super.onClose();
+    }
+
+    @Override
+    public void drawForeground() {
+        super.drawForeground();
+        drawHoveredIngredientTooltip();
+    }
+
+    /**
+     * NEI's native tooltip pass renders before/among widget content and ends up depth-buried
+     * under node widgets, so the hovered ingredient's tooltip is redrawn here: the foreground
+     * phase is the last thing drawn, and depth is explicitly off. The user must never have to
+     * rearrange their chart to read a tooltip.
+     */
+    private void drawHoveredIngredientTooltip() {
+        if (!(getContext().getHovered() instanceof final RecipeViewerIngredientProvider provider)) return;
+        final ItemStack stack = provider.getStackForRecipeViewer();
+        if (stack == null) return;
+        final List<String> lines = codechicken.nei.guihook.GuiContainerManager
+            .itemDisplayNameMultiline(stack, null, true);
+        if (lines.isEmpty()) return;
+        GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_DEPTH_BUFFER_BIT);
+        GL11.glDisable(GL11.GL_DEPTH_TEST);
+        codechicken.lib.gui.GuiDraw
+            .drawMultilineTip(getContext().getAbsMouseX() + 12, getContext().getAbsMouseY() - 12, lines);
+        GL11.glPopAttrib();
     }
 
     // ── Slot bar helpers ──

--- a/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
+++ b/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
@@ -5,17 +5,13 @@ import java.util.List;
 import javax.annotation.Nonnull;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.StatCollector;
-
-import org.lwjgl.opengl.GL11;
 
 import com.cleanroommc.modularui.api.drawable.IKey;
 import com.cleanroommc.modularui.api.widget.Interactable;
 import com.cleanroommc.modularui.drawable.GuiDraw;
 import com.cleanroommc.modularui.drawable.Rectangle;
-import com.cleanroommc.modularui.integration.recipeviewer.RecipeViewerIngredientProvider;
 import com.cleanroommc.modularui.screen.ModularPanel;
 import com.cleanroommc.modularui.screen.ModularScreen;
 import com.cleanroommc.modularui.screen.UISettings;
@@ -239,32 +235,6 @@ public class FlowchartScreen extends ModularScreen {
     public void onClose() {
         PlanAPI.save();
         super.onClose();
-    }
-
-    @Override
-    public void drawForeground() {
-        super.drawForeground();
-        drawHoveredIngredientTooltip();
-    }
-
-    /**
-     * NEI's own tooltip pass can end up depth-buried under node widgets (GL state cache desync
-     * from raw-GL item renderers), so the hovered ingredient's tooltip is redrawn here: the
-     * foreground phase is the last thing drawn, and depth is explicitly off. The user must never
-     * have to rearrange their chart to read a tooltip.
-     */
-    private void drawHoveredIngredientTooltip() {
-        if (!(getContext().getHovered() instanceof final RecipeViewerIngredientProvider provider)) return;
-        final ItemStack stack = provider.getStackForRecipeViewer();
-        if (stack == null) return;
-        final List<String> lines = codechicken.nei.guihook.GuiContainerManager
-            .itemDisplayNameMultiline(stack, null, true);
-        if (lines.isEmpty()) return;
-        GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_DEPTH_BUFFER_BIT);
-        GL11.glDisable(GL11.GL_DEPTH_TEST);
-        codechicken.lib.gui.GuiDraw
-            .drawMultilineTip(getContext().getAbsMouseX() + 12, getContext().getAbsMouseY() - 12, lines);
-        GL11.glPopAttrib();
     }
 
     // ── Slot bar helpers ──

--- a/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
+++ b/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
@@ -5,13 +5,17 @@ import java.util.List;
 import javax.annotation.Nonnull;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.StatCollector;
+
+import org.lwjgl.opengl.GL11;
 
 import com.cleanroommc.modularui.api.drawable.IKey;
 import com.cleanroommc.modularui.api.widget.Interactable;
 import com.cleanroommc.modularui.drawable.GuiDraw;
 import com.cleanroommc.modularui.drawable.Rectangle;
+import com.cleanroommc.modularui.integration.recipeviewer.RecipeViewerIngredientProvider;
 import com.cleanroommc.modularui.screen.ModularPanel;
 import com.cleanroommc.modularui.screen.ModularScreen;
 import com.cleanroommc.modularui.screen.UISettings;
@@ -235,6 +239,33 @@ public class FlowchartScreen extends ModularScreen {
     public void onClose() {
         PlanAPI.save();
         super.onClose();
+    }
+
+    @Override
+    public void drawForeground() {
+        super.drawForeground();
+        drawHoveredIngredientTooltip();
+    }
+
+    /**
+     * Mouse-anchored tooltip (full NEI item tooltip, including handler lines) for the hovered
+     * ingredient: recipe-grid stacks, throughput rows, and port pins. Drawn in the foreground
+     * phase - the last thing rendered, depth off - so it can never be buried by nodes. NEI's own
+     * tooltip pass is suppressed on MUI screens while a widget is hovered, so this is the only
+     * copy.
+     */
+    private void drawHoveredIngredientTooltip() {
+        if (!(getContext().getHovered() instanceof final RecipeViewerIngredientProvider provider)) return;
+        final ItemStack stack = provider.getStackForRecipeViewer();
+        if (stack == null) return;
+        final List<String> lines = codechicken.nei.guihook.GuiContainerManager
+            .itemDisplayNameMultiline(stack, null, true);
+        if (lines.isEmpty()) return;
+        GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_DEPTH_BUFFER_BIT);
+        GL11.glDisable(GL11.GL_DEPTH_TEST);
+        codechicken.lib.gui.GuiDraw
+            .drawMultilineTip(getContext().getAbsMouseX() + 12, getContext().getAbsMouseY() - 12, lines);
+        GL11.glPopAttrib();
     }
 
     // ── Slot bar helpers ──

--- a/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
+++ b/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
@@ -5,17 +5,13 @@ import java.util.List;
 import javax.annotation.Nonnull;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.StatCollector;
-
-import org.lwjgl.opengl.GL11;
 
 import com.cleanroommc.modularui.api.drawable.IKey;
 import com.cleanroommc.modularui.api.widget.Interactable;
 import com.cleanroommc.modularui.drawable.GuiDraw;
 import com.cleanroommc.modularui.drawable.Rectangle;
-import com.cleanroommc.modularui.integration.recipeviewer.RecipeViewerIngredientProvider;
 import com.cleanroommc.modularui.screen.ModularPanel;
 import com.cleanroommc.modularui.screen.ModularScreen;
 import com.cleanroommc.modularui.screen.UISettings;
@@ -239,32 +235,6 @@ public class FlowchartScreen extends ModularScreen {
     public void onClose() {
         PlanAPI.save();
         super.onClose();
-    }
-
-    @Override
-    public void drawForeground() {
-        super.drawForeground();
-        drawHoveredIngredientTooltip();
-    }
-
-    /**
-     * NEI's native tooltip pass renders before/among widget content and ends up depth-buried
-     * under node widgets, so the hovered ingredient's tooltip is redrawn here: the foreground
-     * phase is the last thing drawn, and depth is explicitly off. The user must never have to
-     * rearrange their chart to read a tooltip.
-     */
-    private void drawHoveredIngredientTooltip() {
-        if (!(getContext().getHovered() instanceof final RecipeViewerIngredientProvider provider)) return;
-        final ItemStack stack = provider.getStackForRecipeViewer();
-        if (stack == null) return;
-        final List<String> lines = codechicken.nei.guihook.GuiContainerManager
-            .itemDisplayNameMultiline(stack, null, true);
-        if (lines.isEmpty()) return;
-        GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_DEPTH_BUFFER_BIT);
-        GL11.glDisable(GL11.GL_DEPTH_TEST);
-        codechicken.lib.gui.GuiDraw
-            .drawMultilineTip(getContext().getAbsMouseX() + 12, getContext().getAbsMouseY() - 12, lines);
-        GL11.glPopAttrib();
     }
 
     // ── Slot bar helpers ──

--- a/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
+++ b/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
@@ -1,5 +1,7 @@
 package com.sbancuz.plannh.gui;
 
+import static codechicken.lib.gui.GuiDraw.drawMultilineTip;
+
 import java.util.List;
 
 import javax.annotation.Nonnull;
@@ -15,7 +17,6 @@ import com.cleanroommc.modularui.api.drawable.IKey;
 import com.cleanroommc.modularui.api.widget.Interactable;
 import com.cleanroommc.modularui.drawable.GuiDraw;
 import com.cleanroommc.modularui.drawable.Rectangle;
-import com.cleanroommc.modularui.integration.recipeviewer.RecipeViewerIngredientProvider;
 import com.cleanroommc.modularui.screen.ModularPanel;
 import com.cleanroommc.modularui.screen.ModularScreen;
 import com.cleanroommc.modularui.screen.UISettings;
@@ -43,6 +44,7 @@ import com.sbancuz.plannh.data.flowchart.Summary.SummaryMode;
 import com.sbancuz.plannh.gui.components.CycleButton;
 
 import codechicken.nei.LayoutManager;
+import codechicken.nei.guihook.GuiContainerManager;
 
 public class FlowchartScreen extends ModularScreen {
 
@@ -255,16 +257,16 @@ public class FlowchartScreen extends ModularScreen {
      * copy.
      */
     private void drawHoveredIngredientTooltip() {
-        if (!(getContext().getHovered() instanceof final RecipeViewerIngredientProvider provider)) return;
-        final ItemStack stack = provider.getStackForRecipeViewer();
+        // stackUnderMouse, not getStackForRecipeViewer: the NEI entry point also arms the
+        // pending-lookup origin, and a per-frame tooltip must not mutate lookup state.
+        if (!(getContext().getHovered() instanceof final RecipeNodeWidget nodeWidget)) return;
+        final ItemStack stack = nodeWidget.stackUnderMouse();
         if (stack == null) return;
-        final List<String> lines = codechicken.nei.guihook.GuiContainerManager
-            .itemDisplayNameMultiline(stack, null, true);
+        final List<String> lines = GuiContainerManager.itemDisplayNameMultiline(stack, null, true);
         if (lines.isEmpty()) return;
         GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_DEPTH_BUFFER_BIT);
         GL11.glDisable(GL11.GL_DEPTH_TEST);
-        codechicken.lib.gui.GuiDraw
-            .drawMultilineTip(getContext().getAbsMouseX() + 12, getContext().getAbsMouseY() - 12, lines);
+        drawMultilineTip(getContext().getAbsMouseX() + 12, getContext().getAbsMouseY() - 12, lines);
         GL11.glPopAttrib();
     }
 

--- a/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
+++ b/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
@@ -250,11 +250,9 @@ public class FlowchartScreen extends ModularScreen {
     }
 
     /**
-     * Mouse-anchored tooltip (full NEI item tooltip, including handler lines) for the hovered
-     * ingredient: recipe-grid stacks, throughput rows, and port pins. Drawn in the foreground
-     * phase - the last thing rendered, depth off - so it can never be buried by nodes. NEI's own
-     * tooltip pass is suppressed on MUI screens while a widget is hovered, so this is the only
-     * copy.
+     * Mouse-anchored NEI tooltip for the hovered ingredient (recipe-grid stacks and port
+     * pins), drawn in the foreground phase with depth off so nodes can never bury it. NEI's
+     * own tooltip pass is suppressed on MUI screens while a widget is hovered.
      */
     private void drawHoveredIngredientTooltip() {
         // stackUnderMouse, not getStackForRecipeViewer: the NEI entry point also arms the

--- a/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
+++ b/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
@@ -5,13 +5,17 @@ import java.util.List;
 import javax.annotation.Nonnull;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.StatCollector;
+
+import org.lwjgl.opengl.GL11;
 
 import com.cleanroommc.modularui.api.drawable.IKey;
 import com.cleanroommc.modularui.api.widget.Interactable;
 import com.cleanroommc.modularui.drawable.GuiDraw;
 import com.cleanroommc.modularui.drawable.Rectangle;
+import com.cleanroommc.modularui.integration.recipeviewer.RecipeViewerIngredientProvider;
 import com.cleanroommc.modularui.screen.ModularPanel;
 import com.cleanroommc.modularui.screen.ModularScreen;
 import com.cleanroommc.modularui.screen.UISettings;
@@ -235,6 +239,32 @@ public class FlowchartScreen extends ModularScreen {
     public void onClose() {
         PlanAPI.save();
         super.onClose();
+    }
+
+    @Override
+    public void drawForeground() {
+        super.drawForeground();
+        drawHoveredIngredientTooltip();
+    }
+
+    /**
+     * NEI's own tooltip pass can end up depth-buried under node widgets (GL state cache desync
+     * from raw-GL item renderers), so the hovered ingredient's tooltip is redrawn here: the
+     * foreground phase is the last thing drawn, and depth is explicitly off. The user must never
+     * have to rearrange their chart to read a tooltip.
+     */
+    private void drawHoveredIngredientTooltip() {
+        if (!(getContext().getHovered() instanceof final RecipeViewerIngredientProvider provider)) return;
+        final ItemStack stack = provider.getStackForRecipeViewer();
+        if (stack == null) return;
+        final List<String> lines = codechicken.nei.guihook.GuiContainerManager
+            .itemDisplayNameMultiline(stack, null, true);
+        if (lines.isEmpty()) return;
+        GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_DEPTH_BUFFER_BIT);
+        GL11.glDisable(GL11.GL_DEPTH_TEST);
+        codechicken.lib.gui.GuiDraw
+            .drawMultilineTip(getContext().getAbsMouseX() + 12, getContext().getAbsMouseY() - 12, lines);
+        GL11.glPopAttrib();
     }
 
     // ── Slot bar helpers ──

--- a/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
+++ b/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
@@ -510,8 +510,10 @@ public class FlowchartScreen extends ModularScreen {
                 PlannhColors.SEPARATOR_DIM.getColor());
             ly += HELP_SEP_GAP;
             GuiDraw.drawText(
-                "Zoom: " + canvas.getGraph()
-                    .getZoom() * 100 + "%",
+                "Zoom: " + Math.round(
+                    canvas.getGraph()
+                        .getZoom() * 100)
+                    + "%",
                 ZOOM_TEXT_X,
                 ly,
                 0.9f,

--- a/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
+++ b/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
@@ -1,7 +1,11 @@
 package com.sbancuz.plannh.gui;
 
+import java.awt.image.BufferedImage;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+
+import javax.imageio.ImageIO;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -9,10 +13,12 @@ import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
 import com.cleanroommc.modularui.utils.Color;
+import com.sbancuz.plannh.PlanNH;
 import com.sbancuz.plannh.data.flowchart.Port;
 
 /**
@@ -127,9 +133,13 @@ public final class IngredientColors {
                     b += (long) (rgb & 0xFF) * count;
                     weight += count;
                 }
-                if (weight == 0) return -1;
+                if (weight == 0) {
+                    PlanNH.LOG.debug("No sprite color derivable for {}, using type fallback", k);
+                    return -1;
+                }
                 return (int) (r / weight) << 16 | (int) (g / weight) << 8 | (int) (b / weight);
             } catch (final Exception e) {
+                PlanNH.LOG.debug("Sprite color derivation failed for {}: {}", k, e.toString());
                 return -1;
             }
         });
@@ -143,11 +153,15 @@ public final class IngredientColors {
             try {
                 final long[] modal = modalSpriteColor(fluid.getIcon(fluidStack), true);
                 final int tint = fluid.getColor(fluidStack);
-                if (modal == null) return (tint & 0xFFFFFF) != 0xFFFFFF ? tint & 0xFFFFFF : -1;
+                if (modal == null) {
+                    PlanNH.LOG.debug("No sprite color derivable for {}, using tint/type fallback", k);
+                    return (tint & 0xFFFFFF) != 0xFFFFFF ? tint & 0xFFFFFF : -1;
+                }
                 int rgb = (int) modal[0];
                 if ((tint & 0xFFFFFF) != 0xFFFFFF) rgb = multiplyRgb(rgb, tint);
                 return rgb;
             } catch (final Exception e) {
+                PlanNH.LOG.debug("Sprite color derivation failed for {}: {}", k, e.toString());
                 return -1;
             }
         });
@@ -165,19 +179,60 @@ public final class IngredientColors {
      */
     private static long[] modalSpriteColor(final IIcon icon, final boolean blocksAtlas) {
         if (icon == null) return null;
-        final TextureMap atlas = (TextureMap) Minecraft.getMinecraft()
-            .getTextureManager()
-            .getTexture(blocksAtlas ? TextureMap.locationBlocksTexture : TextureMap.locationItemsTexture);
-        if (atlas == null) return null;
-        final TextureAtlasSprite sprite = atlas.getAtlasSprite(icon.getIconName());
-        if (sprite == null || sprite.getFrameCount() <= 0) return null;
-        final int[][] frame = sprite.getFrameTextureData(0);
-        if (frame == null || frame.length == 0 || frame[0] == null) return null;
+        // Fast path: the stitched atlas' retained CPU-side frame data. Angelica (present in all
+        // modern GTNH packs and this repo's dev runtime) frees that data, so fall back to reading
+        // the sprite's source PNG through the resource manager - the same file the stitcher
+        // loaded it from.
+        long[] result = fromAtlasFrames(icon, blocksAtlas);
+        if (result == null) result = fromResourcePng(icon, blocksAtlas);
+        return result;
+    }
 
-        final int[] pixels = frame[0];
-        final int width = Math.max(1, sprite.getIconWidth());
-        final int height = Math.max(1, pixels.length / width);
+    private static long[] fromAtlasFrames(final IIcon icon, final boolean blocksAtlas) {
+        try {
+            final TextureMap atlas = (TextureMap) Minecraft.getMinecraft()
+                .getTextureManager()
+                .getTexture(blocksAtlas ? TextureMap.locationBlocksTexture : TextureMap.locationItemsTexture);
+            if (atlas == null) return null;
+            final TextureAtlasSprite sprite = atlas.getAtlasSprite(icon.getIconName());
+            if (sprite == null || sprite.getFrameCount() <= 0) return null;
+            final int[][] frame = sprite.getFrameTextureData(0);
+            if (frame == null || frame.length == 0 || frame[0] == null) return null;
 
+            final int[] pixels = frame[0];
+            final int width = Math.max(1, sprite.getIconWidth());
+            return modeWithOutlineFallback(pixels, width, Math.max(1, pixels.length / width));
+        } catch (final Exception e) {
+            return null;
+        }
+    }
+
+    private static long[] fromResourcePng(final IIcon icon, final boolean blocksAtlas) {
+        final String name = icon.getIconName();
+        if (name == null || name.isEmpty()) return null;
+        final int colon = name.indexOf(':');
+        final String domain = colon >= 0 ? name.substring(0, colon) : "minecraft";
+        final String path = colon >= 0 ? name.substring(colon + 1) : name;
+        final ResourceLocation location = new ResourceLocation(
+            domain,
+            "textures/" + (blocksAtlas ? "blocks" : "items") + "/" + path + ".png");
+        try (InputStream in = Minecraft.getMinecraft()
+            .getResourceManager()
+            .getResource(location)
+            .getInputStream()) {
+            final BufferedImage image = ImageIO.read(in);
+            if (image == null) return null;
+            final int width = image.getWidth();
+            // Animated sprites are vertical strips; sample the first frame only.
+            final int height = Math.min(image.getHeight(), width);
+            final int[] pixels = image.getRGB(0, 0, width, height, null, 0, width);
+            return modeWithOutlineFallback(pixels, width, height);
+        } catch (final Exception e) {
+            return null;
+        }
+    }
+
+    private static long[] modeWithOutlineFallback(final int[] pixels, final int width, final int height) {
         long[] result = histogramMode(pixels, width, height, true);
         if (result == null) result = histogramMode(pixels, width, height, false);
         return result;

--- a/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
+++ b/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
@@ -22,6 +22,7 @@ import com.cleanroommc.modularui.utils.Color;
 import com.sbancuz.plannh.PlanNH;
 import com.sbancuz.plannh.data.flowchart.Port;
 
+import gregtech.api.enums.Materials;
 import gregtech.api.items.MetaGeneratedItem;
 
 /**
@@ -134,20 +135,34 @@ public final class IngredientColors {
         final String key = "fluid:" + fluid.getName();
         return CACHE.computeIfAbsent(key, k -> {
             try {
+                // The fluid's own color if it defines one, else GT's material color (fluids like
+                // hydrogen are registered by IC2 with a white color and a generic gas texture -
+                // the GT material knows it should be red).
+                int tint = fluid.getColor(fluidStack);
+                if ((tint & 0xFFFFFF) == 0xFFFFFF) tint = gtFluidMaterialTint(fluid);
+                if ((tint & 0xFFFFFF) != 0xFFFFFF) return tint & 0xFFFFFF;
+
                 final long[] modal = modalSpriteColor(fluid.getIcon(fluidStack), true);
-                final int tint = fluid.getColor(fluidStack);
                 if (modal == null) {
-                    PlanNH.LOG.debug("No sprite color derivable for {}, using tint/type fallback", k);
-                    return (tint & 0xFFFFFF) != 0xFFFFFF ? tint & 0xFFFFFF : -1;
+                    PlanNH.LOG.debug("No sprite color derivable for {}, using type fallback", k);
+                    return -1;
                 }
-                int rgb = (int) modal[0];
-                if ((tint & 0xFFFFFF) != 0xFFFFFF) rgb = multiplyRgb(rgb, tint);
-                return rgb;
+                return (int) modal[0];
             } catch (final Exception e) {
                 PlanNH.LOG.debug("Sprite color derivation failed for {}: {}", k, e.toString());
                 return -1;
             }
         });
+    }
+
+    /** GT material color for a fluid, resolved through GT's fluid-to-material map. */
+    private static int gtFluidMaterialTint(final Fluid fluid) {
+        if (!ModularUI.Mods.GT5U.isLoaded()) return 0xFFFFFF;
+        final Materials material = Materials.FLUID_MAP.get(fluid);
+        if (material != null && material.mRGBa != null && material.mRGBa.length >= 3) {
+            return (material.mRGBa[0] & 0xFF) << 16 | (material.mRGBa[1] & 0xFF) << 8 | (material.mRGBa[2] & 0xFF);
+        }
+        return 0xFFFFFF;
     }
 
     /**

--- a/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
+++ b/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
@@ -1,0 +1,133 @@
+package com.sbancuz.plannh.gui;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.renderer.texture.TextureMap;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.IIcon;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidStack;
+
+import com.cleanroommc.modularui.utils.Color;
+import com.sbancuz.plannh.data.flowchart.Port;
+
+/**
+ * Derives a representative color for an ingredient from its sprite, so ports and edges can be
+ * told apart by what flows through them.
+ *
+ * <p>
+ * The color is the modal color of the sprite's opaque pixels: pixels are binned at 5 bits per
+ * channel and the average color of the fullest bin wins. This tracks the dominant material color
+ * (e.g. copper orange) instead of being washed out by outlines and shading the way a plain
+ * average is.
+ */
+public final class IngredientColors {
+
+    private static final Map<String, Integer> CACHE = new HashMap<>();
+    private static final int ALPHA_OPAQUE_MIN = 128;
+
+    private IngredientColors() {}
+
+    /** Representative ARGB color for the port's ingredient; {@code fallback} (with its alpha) if unknown. */
+    public static int of(final Port<?> port, final int fallback) {
+        final Object value = port.getValue();
+        final int rgb;
+        if (value instanceof final ItemStack stack) {
+            rgb = ofItem(stack);
+        } else if (value instanceof final FluidStack fluidStack) {
+            rgb = ofFluid(fluidStack);
+        } else {
+            rgb = -1;
+        }
+        if (rgb == -1) return fallback;
+        return Color.withAlpha(rgb, Color.getAlpha(fallback));
+    }
+
+    /** Mixes the color toward white, for hover rings and highlights. */
+    public static int brighten(final int color, final float factor) {
+        final int r = Color.getRed(color) + Math.round((255 - Color.getRed(color)) * factor);
+        final int g = Color.getGreen(color) + Math.round((255 - Color.getGreen(color)) * factor);
+        final int b = Color.getBlue(color) + Math.round((255 - Color.getBlue(color)) * factor);
+        return Color.argb(r, g, b, Color.getAlpha(color));
+    }
+
+    private static int ofItem(final ItemStack stack) {
+        if (stack == null || stack.getItem() == null) return -1;
+        final String key = "item:" + Item.itemRegistry.getNameForObject(stack.getItem()) + ":" + stack.getItemDamage();
+        return CACHE.computeIfAbsent(key, k -> {
+            try {
+                final Item item = stack.getItem();
+                final IIcon icon = item.getIconIndex(stack);
+                int rgb = modalSpriteColor(icon, item.getSpriteNumber() == 0);
+                if (rgb == -1) return -1;
+                final int tint = item.getColorFromItemStack(stack, 0);
+                if (tint != 0xFFFFFF) rgb = multiplyRgb(rgb, tint);
+                return rgb;
+            } catch (final Exception e) {
+                return -1;
+            }
+        });
+    }
+
+    private static int ofFluid(final FluidStack fluidStack) {
+        if (fluidStack == null || fluidStack.getFluid() == null) return -1;
+        final Fluid fluid = fluidStack.getFluid();
+        final String key = "fluid:" + fluid.getName();
+        return CACHE.computeIfAbsent(key, k -> {
+            try {
+                int rgb = modalSpriteColor(fluid.getIcon(fluidStack), true);
+                final int tint = fluid.getColor(fluidStack);
+                if (rgb == -1) return (tint & 0xFFFFFF) != 0xFFFFFF ? tint & 0xFFFFFF : -1;
+                if ((tint & 0xFFFFFF) != 0xFFFFFF) rgb = multiplyRgb(rgb, tint);
+                return rgb;
+            } catch (final Exception e) {
+                return -1;
+            }
+        });
+    }
+
+    /** Modal opaque color of an atlas sprite, or -1 if pixels are unavailable. */
+    private static int modalSpriteColor(final IIcon icon, final boolean blocksAtlas) {
+        if (icon == null) return -1;
+        final TextureMap atlas = (TextureMap) Minecraft.getMinecraft()
+            .getTextureManager()
+            .getTexture(blocksAtlas ? TextureMap.locationBlocksTexture : TextureMap.locationItemsTexture);
+        if (atlas == null) return -1;
+        final TextureAtlasSprite sprite = atlas.getAtlasSprite(icon.getIconName());
+        if (sprite == null || sprite.getFrameCount() <= 0) return -1;
+        final int[][] frame = sprite.getFrameTextureData(0);
+        if (frame == null || frame.length == 0 || frame[0] == null) return -1;
+
+        // Bin at 5 bits/channel; remember per-bin sums so the winner can be averaged smoothly.
+        final Map<Integer, long[]> bins = new HashMap<>();
+        for (final int argb : frame[0]) {
+            if ((argb >>> 24) < ALPHA_OPAQUE_MIN) continue;
+            final int r = argb >> 16 & 0xFF;
+            final int g = argb >> 8 & 0xFF;
+            final int b = argb & 0xFF;
+            final int bin = (r >> 3) << 10 | (g >> 3) << 5 | b >> 3;
+            final long[] acc = bins.computeIfAbsent(bin, x -> new long[4]);
+            acc[0]++;
+            acc[1] += r;
+            acc[2] += g;
+            acc[3] += b;
+        }
+        long[] best = null;
+        for (final long[] acc : bins.values()) {
+            if (best == null || acc[0] > best[0]) best = acc;
+        }
+        if (best == null) return -1;
+        return (int) (best[1] / best[0]) << 16 | (int) (best[2] / best[0]) << 8 | (int) (best[3] / best[0]);
+    }
+
+    private static int multiplyRgb(final int rgb, final int tint) {
+        final int r = (rgb >> 16 & 0xFF) * (tint >> 16 & 0xFF) / 255;
+        final int g = (rgb >> 8 & 0xFF) * (tint >> 8 & 0xFF) / 255;
+        final int b = (rgb & 0xFF) * (tint & 0xFF) / 255;
+        return r << 16 | g << 8 | b;
+    }
+}

--- a/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
+++ b/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
@@ -2,6 +2,7 @@ package com.sbancuz.plannh.gui;
 
 import java.awt.image.BufferedImage;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -10,6 +11,7 @@ import javax.imageio.ImageIO;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.texture.TextureMap;
+import net.minecraft.client.shader.Framebuffer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
@@ -17,11 +19,15 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
+import org.lwjgl.BufferUtils;
+import org.lwjgl.opengl.GL11;
+
 import com.cleanroommc.modularui.ModularUI;
 import com.cleanroommc.modularui.utils.Color;
 import com.sbancuz.plannh.PlanNH;
 import com.sbancuz.plannh.data.flowchart.Port;
 
+import codechicken.nei.guihook.GuiContainerManager;
 import gregtech.api.items.MetaGeneratedItem;
 import gregtech.api.util.GTUtility;
 
@@ -89,6 +95,12 @@ public final class IngredientColors {
                 final Item item = stack.getItem();
                 // Multi-render-pass items (all GT material items: gems, dusts, cells...) carry a
                 // grayscale base sprite per pass, tinted by the per-pass color. Blend the passes
+                // Ground truth first: render the stack the way NEI draws it and sample the
+                // pixels. This is immune to the icon API misrepresenting custom renderers
+                // (GT material items, GT blocks, fluid display items...).
+                final long[] rendered = sampleRenderedStack(stack);
+                if (rendered != null) return (int) rendered[0];
+
                 // weighted by how many opaque pixels each contributes.
                 final int passes = item.requiresMultipleRenderPasses()
                     ? Math.max(1, item.getRenderPasses(stack.getItemDamage()))
@@ -140,6 +152,68 @@ public final class IngredientColors {
         final int rgb = computeFluidColor(fluidStack, fluid, key);
         CACHE.put(key, rgb);
         return rgb;
+    }
+
+    private static final int SAMPLE_SIZE = 16;
+
+    /**
+     * Renders the stack into a small offscreen framebuffer via NEI's item drawing (the exact
+     * pipeline recipe screens use) and returns the modal color of the result. Returns null when
+     * rendering is unavailable (headless, GL errors) so callers can fall back to sprite data.
+     */
+    private static long[] sampleRenderedStack(final ItemStack stack) {
+        Framebuffer fbo = null;
+        boolean stateSaved = false;
+        try {
+            final Minecraft mc = Minecraft.getMinecraft();
+            if (mc == null || mc.getTextureManager() == null) return null;
+
+            fbo = new Framebuffer(SAMPLE_SIZE, SAMPLE_SIZE, true);
+            GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
+            GL11.glMatrixMode(GL11.GL_PROJECTION);
+            GL11.glPushMatrix();
+            GL11.glLoadIdentity();
+            GL11.glOrtho(0, SAMPLE_SIZE, SAMPLE_SIZE, 0, -1000, 3000);
+            GL11.glMatrixMode(GL11.GL_MODELVIEW);
+            GL11.glPushMatrix();
+            GL11.glLoadIdentity();
+            stateSaved = true;
+
+            fbo.bindFramebuffer(true);
+            GL11.glClearColor(0f, 0f, 0f, 0f);
+            GL11.glClear(GL11.GL_COLOR_BUFFER_BIT | GL11.GL_DEPTH_BUFFER_BIT);
+            GuiContainerManager.enable2DRender();
+            GuiContainerManager.drawItem(0, 0, stack);
+
+            final ByteBuffer buffer = BufferUtils.createByteBuffer(SAMPLE_SIZE * SAMPLE_SIZE * 4);
+            GL11.glReadPixels(0, 0, SAMPLE_SIZE, SAMPLE_SIZE, GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, buffer);
+            final int[] pixels = new int[SAMPLE_SIZE * SAMPLE_SIZE];
+            for (int i = 0; i < pixels.length; i++) {
+                final int r = buffer.get(i * 4) & 0xFF;
+                final int g = buffer.get(i * 4 + 1) & 0xFF;
+                final int b = buffer.get(i * 4 + 2) & 0xFF;
+                final int a = buffer.get(i * 4 + 3) & 0xFF;
+                pixels[i] = a << 24 | r << 16 | g << 8 | b;
+            }
+            return modeWithOutlineFallback(pixels, SAMPLE_SIZE, SAMPLE_SIZE);
+        } catch (final Exception e) {
+            PlanNH.LOG.debug("Render sampling failed for {}: {}", stack, e.toString());
+            return null;
+        } finally {
+            if (fbo != null) fbo.deleteFramebuffer();
+            try {
+                Minecraft.getMinecraft()
+                    .getFramebuffer()
+                    .bindFramebuffer(true);
+            } catch (final Exception ignored) {}
+            if (stateSaved) {
+                GL11.glMatrixMode(GL11.GL_PROJECTION);
+                GL11.glPopMatrix();
+                GL11.glMatrixMode(GL11.GL_MODELVIEW);
+                GL11.glPopMatrix();
+                GL11.glPopAttrib();
+            }
+        }
     }
 
     private static int computeFluidColor(final FluidStack fluidStack, final Fluid fluid, final String key) {

--- a/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
+++ b/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
@@ -57,8 +57,7 @@ public final class IngredientColors {
 
     /**
      * Contrast outline for a color: light outline under dark colors, dark outline under light
-     * ones. This lets derived colors keep their true luminance (brown stays brown, navy stays
-     * navy) and still read on any world background.
+     * ones, so derived colors read on any world background.
      */
     public static int outlineFor(final int color) {
         return Color.getLuminance(color) < 0.5f ? PlannhColors.EDGE_OUTLINE_LIGHT.getColor()
@@ -67,8 +66,7 @@ public final class IngredientColors {
 
     /**
      * Modal sprite color for an item stack, bare RGB, -1 when none is derivable; the ITEM
-     * resource's color provider. Colors are true to the sprite - readability on arbitrary
-     * backgrounds comes from pairing them with {@link #outlineFor(int)}.
+     * resource's color provider.
      */
     public static int itemColor(final ItemStack stack) {
         if (stack == null || stack.getItem() == null) return UNKNOWN;
@@ -76,9 +74,8 @@ public final class IngredientColors {
         return CACHE.computeIfAbsent(key, k -> {
             try {
                 final Item item = stack.getItem();
-                // Ground truth first: render the stack the way NEI draws it and sample the
-                // pixels. This is immune to the icon API misrepresenting custom renderers
-                // (GT material items, GT blocks, fluid display items...).
+                // Ground truth first: render the stack the way NEI draws it and sample it,
+                // immune to the icon API misrepresenting custom renderers (GT items/blocks).
                 final ModalColor rendered = sampleRenderedStack(stack);
                 if (rendered != null) return logColor(k, rendered.rgb(), "render-sample");
 
@@ -219,7 +216,7 @@ public final class IngredientColors {
             GuiContainerManager.enable2DRender();
             // The sampler is invoked mid-GUI-draw, typically right after untextured rect
             // drawing: texturing must be re-enabled or vanilla-path icons render as flat
-            // white/tint quads (custom renderers that bind their own textures were unaffected).
+            // white/tint quads.
             GL11.glEnable(GL11.GL_TEXTURE_2D);
             GL11.glColor4f(1f, 1f, 1f, 1f);
             // Empty quantity string suppresses the white amount text (fluid displays carry
@@ -263,7 +260,6 @@ public final class IngredientColors {
 
     private static int computeFluidColor(final FluidStack fluidStack, final Fluid fluid, final String key) {
         try {
-            // The fluid's own color if it defines one.
             final int tint = fluid.getColor(fluidStack);
             if ((tint & RGB_MASK) != NO_TINT) return logColor(key, tint & RGB_MASK, "fluid-color");
 

--- a/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
+++ b/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
@@ -100,7 +100,7 @@ public final class IngredientColors {
                 // pixels. This is immune to the icon API misrepresenting custom renderers
                 // (GT material items, GT blocks, fluid display items...).
                 final long[] rendered = sampleRenderedStack(stack);
-                if (rendered != null) return (int) rendered[0];
+                if (rendered != null) return logColor(k, (int) rendered[0], "render-sample");
 
                 // weighted by how many opaque pixels each contributes.
                 final int passes = item.requiresMultipleRenderPasses()
@@ -134,7 +134,7 @@ public final class IngredientColors {
                     PlanNH.LOG.debug("No sprite color derivable for {}, using type fallback", k);
                     return -1;
                 }
-                return (int) (r / weight) << 16 | (int) (g / weight) << 8 | (int) (b / weight);
+                return logColor(k, (int) (r / weight) << 16 | (int) (g / weight) << 8 | (int) (b / weight), "sprite");
             } catch (final Exception e) {
                 PlanNH.LOG.debug("Sprite color derivation failed for {}: {}", k, e.toString());
                 return -1;
@@ -271,7 +271,7 @@ public final class IngredientColors {
         try {
             // The fluid's own color if it defines one.
             final int tint = fluid.getColor(fluidStack);
-            if ((tint & 0xFFFFFF) != 0xFFFFFF) return tint & 0xFFFFFF;
+            if ((tint & 0xFFFFFF) != 0xFFFFFF) return logColor(key, tint & 0xFFFFFF, "fluid-color");
 
             // Otherwise color it the way NEI displays it: GT's fluid display item carries the
             // exact icon + tint combination the player sees in recipe screens.
@@ -279,7 +279,7 @@ public final class IngredientColors {
                 final ItemStack display = GTUtility.getFluidDisplayStack(fluidStack, false);
                 if (display != null) {
                     final int rgb = ofItem(display);
-                    if (rgb != -1) return rgb;
+                    if (rgb != -1) return logColor(key, rgb, "fluid-display");
                 }
             }
 
@@ -288,7 +288,7 @@ public final class IngredientColors {
                 PlanNH.LOG.debug("No sprite color derivable for {}, using type fallback", key);
                 return -1;
             }
-            return (int) modal[0];
+            return logColor(key, (int) modal[0], "fluid-sprite");
         } catch (final Exception e) {
             PlanNH.LOG.debug("Sprite color derivation failed for {}: {}", key, e.toString());
             return -1;
@@ -416,6 +416,11 @@ public final class IngredientColors {
         final int y) {
         if (x < 0 || x >= width || y < 0 || y >= height) return false;
         return (pixels[y * width + x] >>> 24) < ALPHA_OPAQUE_MIN;
+    }
+
+    private static int logColor(final String key, final int rgb, final String source) {
+        PlanNH.LOG.debug("Ingredient color {} -> #{} via {}", key, String.format("%06X", rgb), source);
+        return rgb;
     }
 
     private static int multiplyRgb(final int rgb, final int tint) {

--- a/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
+++ b/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
@@ -26,7 +26,6 @@ import org.lwjgl.opengl.GLContext;
 import com.cleanroommc.modularui.utils.Color;
 import com.sbancuz.plannh.Compat;
 import com.sbancuz.plannh.PlanNH;
-import com.sbancuz.plannh.data.flowchart.Port;
 import com.sbancuz.plannh.data.provider.gregtech.GTHooks;
 
 import codechicken.nei.guihook.GuiContainerManager;
@@ -45,31 +44,16 @@ public final class IngredientColors {
 
     private static final Map<String, Integer> CACHE = new HashMap<>();
     private static final int ALPHA_OPAQUE_MIN = 128;
+    private static final int SAMPLE_SIZE = 16;
 
     private static final int UNKNOWN = -1;
     private static final int NO_TINT = 0xFFFFFF;
     private static final int RGB_MASK = 0xFFFFFF;
 
-    private IngredientColors() {}
+    /** A derived color and the opaque-pixel count that backs it (its weight when blending). */
+    private record ModalColor(int rgb, long weight) {}
 
-    /**
-     * Representative ARGB color for the port's ingredient; {@code fallback} (with its alpha) if
-     * unknown. Colors are true to the sprite - readability on arbitrary backgrounds comes from
-     * pairing them with {@link #outlineFor(int)}.
-     */
-    public static int of(final Port<?> port, final int fallback) {
-        final Object value = port.getValue();
-        final int rgb;
-        if (value instanceof final ItemStack stack) {
-            rgb = ofItem(stack);
-        } else if (value instanceof final FluidStack fluidStack) {
-            rgb = ofFluid(fluidStack);
-        } else {
-            rgb = UNKNOWN;
-        }
-        if (rgb == UNKNOWN) return fallback;
-        return Color.withAlpha(rgb, Color.getAlpha(fallback));
-    }
+    private IngredientColors() {}
 
     /**
      * Contrast outline for a color: light outline under dark colors, dark outline under light
@@ -77,36 +61,34 @@ public final class IngredientColors {
      * navy) and still read on any world background.
      */
     public static int outlineFor(final int color) {
-        final float lum = luminance(
-            Color.getRed(color) / 255f,
-            Color.getGreen(color) / 255f,
-            Color.getBlue(color) / 255f);
-        return lum < 0.5f ? PlannhColors.EDGE_OUTLINE_LIGHT.getColor() : PlannhColors.EDGE_OUTLINE_DARK.getColor();
+        return Color.getLuminance(color) < 0.5f ? PlannhColors.EDGE_OUTLINE_LIGHT.getColor()
+            : PlannhColors.EDGE_OUTLINE_DARK.getColor();
     }
 
-    private static float luminance(final float r, final float g, final float b) {
-        return 0.299f * r + 0.587f * g + 0.114f * b;
-    }
-
-    private static int ofItem(final ItemStack stack) {
+    /**
+     * Modal sprite color for an item stack, bare RGB, -1 when none is derivable; the ITEM
+     * resource's color provider. Colors are true to the sprite - readability on arbitrary
+     * backgrounds comes from pairing them with {@link #outlineFor(int)}.
+     */
+    public static int itemColor(final ItemStack stack) {
         if (stack == null || stack.getItem() == null) return UNKNOWN;
         final String key = "item:" + Item.itemRegistry.getNameForObject(stack.getItem()) + ":" + stack.getItemDamage();
         return CACHE.computeIfAbsent(key, k -> {
             try {
                 final Item item = stack.getItem();
-                // Multi-render-pass items (all GT material items: gems, dusts, cells...) carry a
-                // grayscale base sprite per pass, tinted by the per-pass color. Blend the passes
                 // Ground truth first: render the stack the way NEI draws it and sample the
                 // pixels. This is immune to the icon API misrepresenting custom renderers
                 // (GT material items, GT blocks, fluid display items...).
-                final long[] rendered = sampleRenderedStack(stack);
-                if (rendered != null) return logColor(k, (int) rendered[0], "render-sample");
+                final ModalColor rendered = sampleRenderedStack(stack);
+                if (rendered != null) return logColor(k, rendered.rgb(), "render-sample");
 
+                // Multi-render-pass items (all GT material items: gems, dusts, cells...) carry a
+                // grayscale base sprite per pass, tinted by the per-pass color. Blend the passes
                 // weighted by how many opaque pixels each contributes.
                 final int passes = item.requiresMultipleRenderPasses()
                     ? Math.max(1, item.getRenderPasses(stack.getItemDamage()))
                     : 1;
-                final int gtTint = gtMaterialTint(stack);
+                final int gtTint = Compat.GREGTECH.isLoaded ? GTHooks.materialTint(stack) : NO_TINT;
                 long r = 0, g = 0, b = 0, weight = 0;
                 for (int pass = 0; pass < passes; pass++) {
                     IIcon icon;
@@ -116,25 +98,28 @@ public final class IngredientColors {
                         icon = null;
                     }
                     if (icon == null && pass == 0) icon = item.getIconIndex(stack);
-                    final long[] modal = modalSpriteColor(icon, item.getSpriteNumber() == 0);
+                    final ModalColor modal = modalSpriteColor(icon, item.getSpriteNumber() == 0);
                     if (modal == null) continue;
-                    int rgb = (int) modal[0];
+                    int rgb = modal.rgb();
                     int tint = item.getColorFromItemStack(stack, pass);
                     // GT material items are grayscale sprites tinted by their custom renderer,
                     // not by getColorFromItemStack; apply the material color to the base pass.
                     if (pass == 0 && (tint & RGB_MASK) == NO_TINT) tint = gtTint;
                     if ((tint & RGB_MASK) != NO_TINT) rgb = multiplyRgb(rgb, tint);
-                    final long count = modal[1];
-                    r += (long) (rgb >> 16 & 0xFF) * count;
-                    g += (long) (rgb >> 8 & 0xFF) * count;
-                    b += (long) (rgb & 0xFF) * count;
+                    final long count = modal.weight();
+                    r += (long) Color.getRed(rgb) * count;
+                    g += (long) Color.getGreen(rgb) * count;
+                    b += (long) Color.getBlue(rgb) * count;
                     weight += count;
                 }
                 if (weight == 0) {
                     PlanNH.LOG.debug("No sprite color derivable for {}, using type fallback", k);
                     return UNKNOWN;
                 }
-                return logColor(k, (int) (r / weight) << 16 | (int) (g / weight) << 8 | (int) (b / weight), "sprite");
+                return logColor(
+                    k,
+                    Color.rgb((int) (r / weight), (int) (g / weight), (int) (b / weight)) & RGB_MASK,
+                    "sprite");
             } catch (final Exception e) {
                 PlanNH.LOG.debug("Sprite color derivation failed for {}: {}", k, e.toString());
                 return UNKNOWN;
@@ -142,21 +127,19 @@ public final class IngredientColors {
         });
     }
 
-    private static int ofFluid(final FluidStack fluidStack) {
+    /** Fluid counterpart of {@link #itemColor}; the FLUID resource's color provider. */
+    public static int fluidColor(final FluidStack fluidStack) {
         if (fluidStack == null || fluidStack.getFluid() == null) return UNKNOWN;
         final Fluid fluid = fluidStack.getFluid();
         final String key = "fluid:" + fluid.getName();
         // Manual get/put instead of computeIfAbsent: the display-stack path recurses into
-        // ofItem, and nested computeIfAbsent on one map is illegal.
+        // itemColor, and nested computeIfAbsent on one map is illegal.
         final Integer cached = CACHE.get(key);
         if (cached != null) return cached;
         final int rgb = computeFluidColor(fluidStack, fluid, key);
         CACHE.put(key, rgb);
         return rgb;
     }
-
-    private static final int SAMPLE_SIZE = 16;
-    private static final int GL_FRAMEBUFFER_BINDING = 0x8CA6;
 
     /**
      * Renders the stack into a small offscreen framebuffer via NEI's item drawing (the exact
@@ -169,12 +152,12 @@ public final class IngredientColors {
      * can silently no-op its bind, which would make this read back whatever is currently on
      * screen. The binding is verified before anything is drawn.
      */
-    private static long[] sampleRenderedStack(final ItemStack stack) {
+    private static ModalColor sampleRenderedStack(final ItemStack stack) {
         final Minecraft mc = Minecraft.getMinecraft();
         if (mc == null || mc.getTextureManager() == null) return null;
         if (!GLContext.getCapabilities().OpenGL30) return null;
 
-        final int previousFbo = GL11.glGetInteger(GL_FRAMEBUFFER_BINDING);
+        final int previousFbo = GL11.glGetInteger(GL30.GL_FRAMEBUFFER_BINDING);
         int fbo = 0;
         int colorTexture = 0;
         int depthBuffer = 0;
@@ -200,7 +183,7 @@ public final class IngredientColors {
 
             fbo = GL30.glGenFramebuffers();
             GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, fbo);
-            if (GL11.glGetInteger(GL_FRAMEBUFFER_BINDING) != fbo) {
+            if (GL11.glGetInteger(GL30.GL_FRAMEBUFFER_BINDING) != fbo) {
                 PlanNH.LOG.debug("FBO bind did not take for {}, falling back to sprites", stack);
                 return null;
             }
@@ -251,9 +234,9 @@ public final class IngredientColors {
                 final int g = buffer.get(i * 4 + 1) & 0xFF;
                 final int b = buffer.get(i * 4 + 2) & 0xFF;
                 final int a = buffer.get(i * 4 + 3) & 0xFF;
-                pixels[i] = a << 24 | r << 16 | g << 8 | b;
+                pixels[i] = Color.argb(r, g, b, a);
             }
-            final long[] result = modeWithOutlineFallback(pixels, SAMPLE_SIZE, SAMPLE_SIZE);
+            final ModalColor result = modeWithOutlineFallback(pixels, SAMPLE_SIZE, SAMPLE_SIZE);
             if (result == null) {
                 PlanNH.LOG.debug("Render sample of {} produced no opaque pixels", stack);
             }
@@ -289,17 +272,17 @@ public final class IngredientColors {
             if (Compat.GREGTECH.isLoaded) {
                 final ItemStack display = GTHooks.fluidDisplayStack(fluidStack);
                 if (display != null) {
-                    final int rgb = ofItem(display);
+                    final int rgb = itemColor(display);
                     if (rgb != UNKNOWN) return logColor(key, rgb, "fluid-display");
                 }
             }
 
-            final long[] modal = modalSpriteColor(fluid.getIcon(fluidStack), true);
+            final ModalColor modal = modalSpriteColor(fluid.getIcon(fluidStack), true);
             if (modal == null) {
                 PlanNH.LOG.debug("No sprite color derivable for {}, using type fallback", key);
                 return UNKNOWN;
             }
-            return logColor(key, (int) modal[0], "fluid-sprite");
+            return logColor(key, modal.rgb(), "fluid-sprite");
         } catch (final Exception e) {
             PlanNH.LOG.debug("Sprite color derivation failed for {}: {}", key, e.toString());
             return UNKNOWN;
@@ -307,8 +290,7 @@ public final class IngredientColors {
     }
 
     /**
-     * Modal opaque color of an atlas sprite as {@code [rgb, opaquePixelCount]}, or null if pixels
-     * are unavailable.
+     * Modal opaque color of an atlas sprite, or null if pixels are unavailable.
      *
      * <p>
      * Sprite outlines are excluded first: any opaque pixel touching a transparent one is part of
@@ -316,14 +298,14 @@ public final class IngredientColors {
      * heavy sprites like the diamond. If erosion leaves nothing (very thin sprites), the full
      * opaque set is used instead.
      */
-    private static long[] modalSpriteColor(final IIcon icon, final boolean blocksAtlas) {
+    private static ModalColor modalSpriteColor(final IIcon icon, final boolean blocksAtlas) {
         if (icon == null) return null;
         // Fast path: the stitched atlas' retained CPU-side frame data. Angelica (present in all
         // modern GTNH packs and this repo's dev runtime) frees that data, so fall back to reading
         // the sprite's source PNG through the resource manager - the same file the stitcher
         // loaded it from. Items that borrow icons from the other atlas (e.g. GT's fluid display
         // uses block-atlas fluid icons) get a cross-atlas retry.
-        long[] result = fromAtlasFrames(icon, blocksAtlas);
+        ModalColor result = fromAtlasFrames(icon, blocksAtlas);
         if (result == null) result = fromResourcePng(icon, blocksAtlas);
         if (result == null) result = fromAtlasFrames(icon, !blocksAtlas);
         if (result == null) result = fromResourcePng(icon, !blocksAtlas);
@@ -333,7 +315,7 @@ public final class IngredientColors {
         return result;
     }
 
-    private static long[] fromAtlasFrames(final IIcon icon, final boolean blocksAtlas) {
+    private static ModalColor fromAtlasFrames(final IIcon icon, final boolean blocksAtlas) {
         try {
             final TextureMap atlas = (TextureMap) Minecraft.getMinecraft()
                 .getTextureManager()
@@ -352,7 +334,7 @@ public final class IngredientColors {
         }
     }
 
-    private static long[] fromResourcePng(final IIcon icon, final boolean blocksAtlas) {
+    private static ModalColor fromResourcePng(final IIcon icon, final boolean blocksAtlas) {
         final String name = icon.getIconName();
         if (name == null || name.isEmpty()) return null;
         final int colon = name.indexOf(':');
@@ -381,26 +363,26 @@ public final class IngredientColors {
         }
     }
 
-    private static long[] modeWithOutlineFallback(final int[] pixels, final int width, final int height) {
-        long[] result = histogramMode(pixels, width, height, true);
+    private static ModalColor modeWithOutlineFallback(final int[] pixels, final int width, final int height) {
+        ModalColor result = histogramMode(pixels, width, height, true);
         if (result == null) result = histogramMode(pixels, width, height, false);
         return result;
     }
 
     /** Bin at 5 bits/channel; per-bin sums let the winning bin be averaged smoothly. */
-    private static long[] histogramMode(final int[] pixels, final int width, final int height,
+    private static ModalColor histogramMode(final int[] pixels, final int width, final int height,
         final boolean erodeOutline) {
         final Map<Integer, long[]> bins = new HashMap<>();
         long opaque = 0;
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
                 final int argb = pixels[y * width + x];
-                if ((argb >>> 24) < ALPHA_OPAQUE_MIN) continue;
+                if (Color.getAlpha(argb) < ALPHA_OPAQUE_MIN) continue;
                 if (erodeOutline && touchesTransparency(pixels, width, height, x, y)) continue;
                 opaque++;
-                final int r = argb >> 16 & 0xFF;
-                final int g = argb >> 8 & 0xFF;
-                final int b = argb & 0xFF;
+                final int r = Color.getRed(argb);
+                final int g = Color.getGreen(argb);
+                final int b = Color.getBlue(argb);
                 final int bin = (r >> 3) << 10 | (g >> 3) << 5 | b >> 3;
                 final long[] acc = bins.computeIfAbsent(bin, x2 -> new long[4]);
                 acc[0]++;
@@ -428,8 +410,9 @@ public final class IngredientColors {
             }
         }
         if (best == null) return null;
-        final int rgb = (int) (best[1] / best[0]) << 16 | (int) (best[2] / best[0]) << 8 | (int) (best[3] / best[0]);
-        return new long[] { rgb, opaque };
+        final int rgb = Color.rgb((int) (best[1] / best[0]), (int) (best[2] / best[0]), (int) (best[3] / best[0]))
+            & RGB_MASK;
+        return new ModalColor(rgb, opaque);
     }
 
     /** True if a 4-neighbor is transparent; out-of-bounds neighbors count as opaque. */
@@ -443,7 +426,7 @@ public final class IngredientColors {
     private static boolean isTransparent(final int[] pixels, final int width, final int height, final int x,
         final int y) {
         if (x < 0 || x >= width || y < 0 || y >= height) return false;
-        return (pixels[y * width + x] >>> 24) < ALPHA_OPAQUE_MIN;
+        return Color.getAlpha(pixels[y * width + x]) < ALPHA_OPAQUE_MIN;
     }
 
     private static int logColor(final String key, final int rgb, final String source) {
@@ -457,10 +440,5 @@ public final class IngredientColors {
             Color.getRed(rgb) * Color.getRed(tint) / 255,
             Color.getGreen(rgb) * Color.getGreen(tint) / 255,
             Color.getBlue(rgb) * Color.getBlue(tint) / 255) & RGB_MASK;
-    }
-
-    /** GT material color for MetaGeneratedItems (their renderer applies it, so the item API lies). */
-    private static int gtMaterialTint(final ItemStack stack) {
-        return Compat.GREGTECH.isLoaded ? GTHooks.materialTint(stack) : NO_TINT;
     }
 }

--- a/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
+++ b/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
@@ -234,6 +234,11 @@ public final class IngredientColors {
             GL11.glClearColor(0f, 0f, 0f, 0f);
             GL11.glClear(GL11.GL_COLOR_BUFFER_BIT | GL11.GL_DEPTH_BUFFER_BIT);
             GuiContainerManager.enable2DRender();
+            // The sampler is invoked mid-GUI-draw, typically right after untextured rect
+            // drawing: texturing must be re-enabled or vanilla-path icons render as flat
+            // white/tint quads (custom renderers that bind their own textures were unaffected).
+            GL11.glEnable(GL11.GL_TEXTURE_2D);
+            GL11.glColor4f(1f, 1f, 1f, 1f);
             // Empty quantity string suppresses the white amount text (fluid displays carry
             // one), which otherwise wins the modal vote over pale sprites.
             GuiContainerManager.drawItem(0, 0, stack, false, "");

--- a/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
+++ b/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
@@ -30,6 +30,13 @@ public final class IngredientColors {
     private static final Map<String, Integer> CACHE = new HashMap<>();
     private static final int ALPHA_OPAQUE_MIN = 128;
 
+    /**
+     * Minimum perceived luminance for derived colors. The canvas background is the world, which
+     * can be nearly black at night, so dark sprite colors (e.g. ethenone's navy) are lifted to
+     * stay legible while keeping their hue.
+     */
+    private static final float MIN_LUMINANCE = 0.42f;
+
     private IngredientColors() {}
 
     /** Representative ARGB color for the port's ingredient; {@code fallback} (with its alpha) if unknown. */
@@ -44,7 +51,40 @@ public final class IngredientColors {
             rgb = -1;
         }
         if (rgb == -1) return fallback;
-        return Color.withAlpha(rgb, Color.getAlpha(fallback));
+        return Color.withAlpha(ensureReadable(rgb), Color.getAlpha(fallback));
+    }
+
+    /**
+     * Lifts a color to {@link #MIN_LUMINANCE}: first scaled up (preserves saturation), then
+     * blended toward white for whatever channel clipping ate (a saturated navy can't reach the
+     * target by scaling alone).
+     */
+    private static int ensureReadable(final int rgb) {
+        float r = (rgb >> 16 & 0xFF) / 255f;
+        float g = (rgb >> 8 & 0xFF) / 255f;
+        float b = (rgb & 0xFF) / 255f;
+        float lum = luminance(r, g, b);
+        if (lum >= MIN_LUMINANCE) return rgb;
+        if (lum < 0.004f) {
+            final int v = Math.round(MIN_LUMINANCE * 255);
+            return v << 16 | v << 8 | v;
+        }
+        final float scale = MIN_LUMINANCE / lum;
+        r = Math.min(1f, r * scale);
+        g = Math.min(1f, g * scale);
+        b = Math.min(1f, b * scale);
+        lum = luminance(r, g, b);
+        if (lum < MIN_LUMINANCE) {
+            final float t = (MIN_LUMINANCE - lum) / (1f - lum);
+            r += (1f - r) * t;
+            g += (1f - g) * t;
+            b += (1f - b) * t;
+        }
+        return Math.round(r * 255) << 16 | Math.round(g * 255) << 8 | Math.round(b * 255);
+    }
+
+    private static float luminance(final float r, final float g, final float b) {
+        return 0.299f * r + 0.587f * g + 0.114f * b;
     }
 
     /** Mixes the color toward white, for hover rings and highlights. */

--- a/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
+++ b/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
@@ -101,12 +101,34 @@ public final class IngredientColors {
         return CACHE.computeIfAbsent(key, k -> {
             try {
                 final Item item = stack.getItem();
-                final IIcon icon = item.getIconIndex(stack);
-                int rgb = modalSpriteColor(icon, item.getSpriteNumber() == 0);
-                if (rgb == -1) return -1;
-                final int tint = item.getColorFromItemStack(stack, 0);
-                if (tint != 0xFFFFFF) rgb = multiplyRgb(rgb, tint);
-                return rgb;
+                // Multi-render-pass items (all GT material items: gems, dusts, cells...) carry a
+                // grayscale base sprite per pass, tinted by the per-pass color. Blend the passes
+                // weighted by how many opaque pixels each contributes.
+                final int passes = item.requiresMultipleRenderPasses()
+                    ? Math.max(1, item.getRenderPasses(stack.getItemDamage()))
+                    : 1;
+                long r = 0, g = 0, b = 0, weight = 0;
+                for (int pass = 0; pass < passes; pass++) {
+                    IIcon icon;
+                    try {
+                        icon = item.getIcon(stack, pass);
+                    } catch (final Exception e) {
+                        icon = null;
+                    }
+                    if (icon == null && pass == 0) icon = item.getIconIndex(stack);
+                    final long[] modal = modalSpriteColor(icon, item.getSpriteNumber() == 0);
+                    if (modal == null) continue;
+                    int rgb = (int) modal[0];
+                    final int tint = item.getColorFromItemStack(stack, pass);
+                    if ((tint & 0xFFFFFF) != 0xFFFFFF) rgb = multiplyRgb(rgb, tint);
+                    final long count = modal[1];
+                    r += (long) (rgb >> 16 & 0xFF) * count;
+                    g += (long) (rgb >> 8 & 0xFF) * count;
+                    b += (long) (rgb & 0xFF) * count;
+                    weight += count;
+                }
+                if (weight == 0) return -1;
+                return (int) (r / weight) << 16 | (int) (g / weight) << 8 | (int) (b / weight);
             } catch (final Exception e) {
                 return -1;
             }
@@ -119,9 +141,10 @@ public final class IngredientColors {
         final String key = "fluid:" + fluid.getName();
         return CACHE.computeIfAbsent(key, k -> {
             try {
-                int rgb = modalSpriteColor(fluid.getIcon(fluidStack), true);
+                final long[] modal = modalSpriteColor(fluid.getIcon(fluidStack), true);
                 final int tint = fluid.getColor(fluidStack);
-                if (rgb == -1) return (tint & 0xFFFFFF) != 0xFFFFFF ? tint & 0xFFFFFF : -1;
+                if (modal == null) return (tint & 0xFFFFFF) != 0xFFFFFF ? tint & 0xFFFFFF : -1;
+                int rgb = (int) modal[0];
                 if ((tint & 0xFFFFFF) != 0xFFFFFF) rgb = multiplyRgb(rgb, tint);
                 return rgb;
             } catch (final Exception e) {
@@ -130,38 +153,79 @@ public final class IngredientColors {
         });
     }
 
-    /** Modal opaque color of an atlas sprite, or -1 if pixels are unavailable. */
-    private static int modalSpriteColor(final IIcon icon, final boolean blocksAtlas) {
-        if (icon == null) return -1;
+    /**
+     * Modal opaque color of an atlas sprite as {@code [rgb, opaquePixelCount]}, or null if pixels
+     * are unavailable.
+     *
+     * <p>
+     * Sprite outlines are excluded first: any opaque pixel touching a transparent one is part of
+     * the (usually darkened) outline ring and would otherwise win the modal vote on gradient-
+     * heavy sprites like the diamond. If erosion leaves nothing (very thin sprites), the full
+     * opaque set is used instead.
+     */
+    private static long[] modalSpriteColor(final IIcon icon, final boolean blocksAtlas) {
+        if (icon == null) return null;
         final TextureMap atlas = (TextureMap) Minecraft.getMinecraft()
             .getTextureManager()
             .getTexture(blocksAtlas ? TextureMap.locationBlocksTexture : TextureMap.locationItemsTexture);
-        if (atlas == null) return -1;
+        if (atlas == null) return null;
         final TextureAtlasSprite sprite = atlas.getAtlasSprite(icon.getIconName());
-        if (sprite == null || sprite.getFrameCount() <= 0) return -1;
+        if (sprite == null || sprite.getFrameCount() <= 0) return null;
         final int[][] frame = sprite.getFrameTextureData(0);
-        if (frame == null || frame.length == 0 || frame[0] == null) return -1;
+        if (frame == null || frame.length == 0 || frame[0] == null) return null;
 
-        // Bin at 5 bits/channel; remember per-bin sums so the winner can be averaged smoothly.
+        final int[] pixels = frame[0];
+        final int width = Math.max(1, sprite.getIconWidth());
+        final int height = Math.max(1, pixels.length / width);
+
+        long[] result = histogramMode(pixels, width, height, true);
+        if (result == null) result = histogramMode(pixels, width, height, false);
+        return result;
+    }
+
+    /** Bin at 5 bits/channel; per-bin sums let the winning bin be averaged smoothly. */
+    private static long[] histogramMode(final int[] pixels, final int width, final int height,
+        final boolean erodeOutline) {
         final Map<Integer, long[]> bins = new HashMap<>();
-        for (final int argb : frame[0]) {
-            if ((argb >>> 24) < ALPHA_OPAQUE_MIN) continue;
-            final int r = argb >> 16 & 0xFF;
-            final int g = argb >> 8 & 0xFF;
-            final int b = argb & 0xFF;
-            final int bin = (r >> 3) << 10 | (g >> 3) << 5 | b >> 3;
-            final long[] acc = bins.computeIfAbsent(bin, x -> new long[4]);
-            acc[0]++;
-            acc[1] += r;
-            acc[2] += g;
-            acc[3] += b;
+        long opaque = 0;
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                final int argb = pixels[y * width + x];
+                if ((argb >>> 24) < ALPHA_OPAQUE_MIN) continue;
+                if (erodeOutline && touchesTransparency(pixels, width, height, x, y)) continue;
+                opaque++;
+                final int r = argb >> 16 & 0xFF;
+                final int g = argb >> 8 & 0xFF;
+                final int b = argb & 0xFF;
+                final int bin = (r >> 3) << 10 | (g >> 3) << 5 | b >> 3;
+                final long[] acc = bins.computeIfAbsent(bin, x2 -> new long[4]);
+                acc[0]++;
+                acc[1] += r;
+                acc[2] += g;
+                acc[3] += b;
+            }
         }
         long[] best = null;
         for (final long[] acc : bins.values()) {
             if (best == null || acc[0] > best[0]) best = acc;
         }
-        if (best == null) return -1;
-        return (int) (best[1] / best[0]) << 16 | (int) (best[2] / best[0]) << 8 | (int) (best[3] / best[0]);
+        if (best == null) return null;
+        final int rgb = (int) (best[1] / best[0]) << 16 | (int) (best[2] / best[0]) << 8 | (int) (best[3] / best[0]);
+        return new long[] { rgb, opaque };
+    }
+
+    /** True if a 4-neighbor is transparent; out-of-bounds neighbors count as opaque. */
+    private static boolean touchesTransparency(final int[] pixels, final int width, final int height, final int x,
+        final int y) {
+        return isTransparent(pixels, width, height, x - 1, y) || isTransparent(pixels, width, height, x + 1, y)
+            || isTransparent(pixels, width, height, x, y - 1)
+            || isTransparent(pixels, width, height, x, y + 1);
+    }
+
+    private static boolean isTransparent(final int[] pixels, final int width, final int height, final int x,
+        final int y) {
+        if (x < 0 || x >= width || y < 0 || y >= height) return false;
+        return (pixels[y * width + x] >>> 24) < ALPHA_OPAQUE_MIN;
     }
 
     private static int multiplyRgb(final int rgb, final int tint) {

--- a/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
+++ b/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
@@ -191,6 +191,9 @@ public final class IngredientColors {
         if (result == null) result = fromResourcePng(icon, blocksAtlas);
         if (result == null) result = fromAtlasFrames(icon, !blocksAtlas);
         if (result == null) result = fromResourcePng(icon, !blocksAtlas);
+        if (result == null) {
+            PlanNH.LOG.debug("No pixels found for icon '{}' (blocksAtlas={})", icon.getIconName(), blocksAtlas);
+        }
         return result;
     }
 
@@ -234,6 +237,7 @@ public final class IngredientColors {
             final int[] pixels = image.getRGB(0, 0, width, height, null, 0, width);
             return modeWithOutlineFallback(pixels, width, height);
         } catch (final Exception e) {
+            PlanNH.LOG.debug("PNG read failed for icon '{}' at {}: {}", name, location, e.toString());
             return null;
         }
     }

--- a/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
+++ b/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
@@ -22,8 +22,8 @@ import com.cleanroommc.modularui.utils.Color;
 import com.sbancuz.plannh.PlanNH;
 import com.sbancuz.plannh.data.flowchart.Port;
 
-import gregtech.api.enums.Materials;
 import gregtech.api.items.MetaGeneratedItem;
+import gregtech.api.util.GTUtility;
 
 /**
  * Derives a representative color for an ingredient from its sprite, so ports and edges can be
@@ -133,36 +133,41 @@ public final class IngredientColors {
         if (fluidStack == null || fluidStack.getFluid() == null) return -1;
         final Fluid fluid = fluidStack.getFluid();
         final String key = "fluid:" + fluid.getName();
-        return CACHE.computeIfAbsent(key, k -> {
-            try {
-                // The fluid's own color if it defines one, else GT's material color (fluids like
-                // hydrogen are registered by IC2 with a white color and a generic gas texture -
-                // the GT material knows it should be red).
-                int tint = fluid.getColor(fluidStack);
-                if ((tint & 0xFFFFFF) == 0xFFFFFF) tint = gtFluidMaterialTint(fluid);
-                if ((tint & 0xFFFFFF) != 0xFFFFFF) return tint & 0xFFFFFF;
-
-                final long[] modal = modalSpriteColor(fluid.getIcon(fluidStack), true);
-                if (modal == null) {
-                    PlanNH.LOG.debug("No sprite color derivable for {}, using type fallback", k);
-                    return -1;
-                }
-                return (int) modal[0];
-            } catch (final Exception e) {
-                PlanNH.LOG.debug("Sprite color derivation failed for {}: {}", k, e.toString());
-                return -1;
-            }
-        });
+        // Manual get/put instead of computeIfAbsent: the display-stack path recurses into
+        // ofItem, and nested computeIfAbsent on one map is illegal.
+        final Integer cached = CACHE.get(key);
+        if (cached != null) return cached;
+        final int rgb = computeFluidColor(fluidStack, fluid, key);
+        CACHE.put(key, rgb);
+        return rgb;
     }
 
-    /** GT material color for a fluid, resolved through GT's fluid-to-material map. */
-    private static int gtFluidMaterialTint(final Fluid fluid) {
-        if (!ModularUI.Mods.GT5U.isLoaded()) return 0xFFFFFF;
-        final Materials material = Materials.FLUID_MAP.get(fluid);
-        if (material != null && material.mRGBa != null && material.mRGBa.length >= 3) {
-            return (material.mRGBa[0] & 0xFF) << 16 | (material.mRGBa[1] & 0xFF) << 8 | (material.mRGBa[2] & 0xFF);
+    private static int computeFluidColor(final FluidStack fluidStack, final Fluid fluid, final String key) {
+        try {
+            // The fluid's own color if it defines one.
+            final int tint = fluid.getColor(fluidStack);
+            if ((tint & 0xFFFFFF) != 0xFFFFFF) return tint & 0xFFFFFF;
+
+            // Otherwise color it the way NEI displays it: GT's fluid display item carries the
+            // exact icon + tint combination the player sees in recipe screens.
+            if (ModularUI.Mods.GT5U.isLoaded()) {
+                final ItemStack display = GTUtility.getFluidDisplayStack(fluidStack, false);
+                if (display != null) {
+                    final int rgb = ofItem(display);
+                    if (rgb != -1) return rgb;
+                }
+            }
+
+            final long[] modal = modalSpriteColor(fluid.getIcon(fluidStack), true);
+            if (modal == null) {
+                PlanNH.LOG.debug("No sprite color derivable for {}, using type fallback", key);
+                return -1;
+            }
+            return (int) modal[0];
+        } catch (final Exception e) {
+            PlanNH.LOG.debug("Sprite color derivation failed for {}: {}", key, e.toString());
+            return -1;
         }
-        return 0xFFFFFF;
     }
 
     /**
@@ -180,9 +185,12 @@ public final class IngredientColors {
         // Fast path: the stitched atlas' retained CPU-side frame data. Angelica (present in all
         // modern GTNH packs and this repo's dev runtime) frees that data, so fall back to reading
         // the sprite's source PNG through the resource manager - the same file the stitcher
-        // loaded it from.
+        // loaded it from. Items that borrow icons from the other atlas (e.g. GT's fluid display
+        // uses block-atlas fluid icons) get a cross-atlas retry.
         long[] result = fromAtlasFrames(icon, blocksAtlas);
         if (result == null) result = fromResourcePng(icon, blocksAtlas);
+        if (result == null) result = fromAtlasFrames(icon, !blocksAtlas);
+        if (result == null) result = fromResourcePng(icon, !blocksAtlas);
         return result;
     }
 

--- a/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
+++ b/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
@@ -11,7 +11,6 @@ import javax.imageio.ImageIO;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.texture.TextureMap;
-import net.minecraft.client.shader.Framebuffer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
@@ -21,6 +20,8 @@ import net.minecraftforge.fluids.FluidStack;
 
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL30;
+import org.lwjgl.opengl.GLContext;
 
 import com.cleanroommc.modularui.ModularUI;
 import com.cleanroommc.modularui.utils.Color;
@@ -155,20 +156,70 @@ public final class IngredientColors {
     }
 
     private static final int SAMPLE_SIZE = 16;
+    private static final int GL_FRAMEBUFFER_BINDING = 0x8CA6;
 
     /**
      * Renders the stack into a small offscreen framebuffer via NEI's item drawing (the exact
      * pipeline recipe screens use) and returns the modal color of the result. Returns null when
-     * rendering is unavailable (headless, GL errors) so callers can fall back to sprite data.
+     * rendering is unavailable (headless, no FBO support, binding hijacked by render mods) so
+     * callers can fall back to sprite data.
+     *
+     * <p>
+     * Uses raw GL FBOs instead of Minecraft's Framebuffer wrapper: under Angelica the wrapper
+     * can silently no-op its bind, which would make this read back whatever is currently on
+     * screen. The binding is verified before anything is drawn.
      */
     private static long[] sampleRenderedStack(final ItemStack stack) {
-        Framebuffer fbo = null;
+        final Minecraft mc = Minecraft.getMinecraft();
+        if (mc == null || mc.getTextureManager() == null) return null;
+        if (!GLContext.getCapabilities().OpenGL30) return null;
+
+        final int previousFbo = GL11.glGetInteger(GL_FRAMEBUFFER_BINDING);
+        int fbo = 0;
+        int colorTexture = 0;
+        int depthBuffer = 0;
         boolean stateSaved = false;
         try {
-            final Minecraft mc = Minecraft.getMinecraft();
-            if (mc == null || mc.getTextureManager() == null) return null;
+            colorTexture = GL11.glGenTextures();
+            GL11.glBindTexture(GL11.GL_TEXTURE_2D, colorTexture);
+            GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_NEAREST);
+            GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_NEAREST);
+            GL11.glTexImage2D(
+                GL11.GL_TEXTURE_2D,
+                0,
+                GL11.GL_RGBA8,
+                SAMPLE_SIZE,
+                SAMPLE_SIZE,
+                0,
+                GL11.GL_RGBA,
+                GL11.GL_UNSIGNED_BYTE,
+                (ByteBuffer) null);
+            depthBuffer = GL30.glGenRenderbuffers();
+            GL30.glBindRenderbuffer(GL30.GL_RENDERBUFFER, depthBuffer);
+            GL30.glRenderbufferStorage(GL30.GL_RENDERBUFFER, GL11.GL_DEPTH_COMPONENT, SAMPLE_SIZE, SAMPLE_SIZE);
 
-            fbo = new Framebuffer(SAMPLE_SIZE, SAMPLE_SIZE, true);
+            fbo = GL30.glGenFramebuffers();
+            GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, fbo);
+            if (GL11.glGetInteger(GL_FRAMEBUFFER_BINDING) != fbo) {
+                PlanNH.LOG.debug("FBO bind did not take for {}, falling back to sprites", stack);
+                return null;
+            }
+            GL30.glFramebufferTexture2D(
+                GL30.GL_FRAMEBUFFER,
+                GL30.GL_COLOR_ATTACHMENT0,
+                GL11.GL_TEXTURE_2D,
+                colorTexture,
+                0);
+            GL30.glFramebufferRenderbuffer(
+                GL30.GL_FRAMEBUFFER,
+                GL30.GL_DEPTH_ATTACHMENT,
+                GL30.GL_RENDERBUFFER,
+                depthBuffer);
+            if (GL30.glCheckFramebufferStatus(GL30.GL_FRAMEBUFFER) != GL30.GL_FRAMEBUFFER_COMPLETE) {
+                PlanNH.LOG.debug("FBO incomplete for {}, falling back to sprites", stack);
+                return null;
+            }
+
             GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
             GL11.glMatrixMode(GL11.GL_PROJECTION);
             GL11.glPushMatrix();
@@ -179,7 +230,7 @@ public final class IngredientColors {
             GL11.glLoadIdentity();
             stateSaved = true;
 
-            fbo.bindFramebuffer(true);
+            GL11.glViewport(0, 0, SAMPLE_SIZE, SAMPLE_SIZE);
             GL11.glClearColor(0f, 0f, 0f, 0f);
             GL11.glClear(GL11.GL_COLOR_BUFFER_BIT | GL11.GL_DEPTH_BUFFER_BIT);
             GuiContainerManager.enable2DRender();
@@ -200,12 +251,6 @@ public final class IngredientColors {
             PlanNH.LOG.debug("Render sampling failed for {}: {}", stack, e.toString());
             return null;
         } finally {
-            if (fbo != null) fbo.deleteFramebuffer();
-            try {
-                Minecraft.getMinecraft()
-                    .getFramebuffer()
-                    .bindFramebuffer(true);
-            } catch (final Exception ignored) {}
             if (stateSaved) {
                 GL11.glMatrixMode(GL11.GL_PROJECTION);
                 GL11.glPopMatrix();
@@ -213,6 +258,12 @@ public final class IngredientColors {
                 GL11.glPopMatrix();
                 GL11.glPopAttrib();
             }
+            try {
+                GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, previousFbo);
+            } catch (final Exception ignored) {}
+            if (fbo != 0) GL30.glDeleteFramebuffers(fbo);
+            if (depthBuffer != 0) GL30.glDeleteRenderbuffers(depthBuffer);
+            if (colorTexture != 0) GL11.glDeleteTextures(colorTexture);
         }
     }
 

--- a/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
+++ b/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
@@ -23,14 +23,13 @@ import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL30;
 import org.lwjgl.opengl.GLContext;
 
-import com.cleanroommc.modularui.ModularUI;
 import com.cleanroommc.modularui.utils.Color;
+import com.sbancuz.plannh.Compat;
 import com.sbancuz.plannh.PlanNH;
 import com.sbancuz.plannh.data.flowchart.Port;
+import com.sbancuz.plannh.data.provider.gregtech.GTHooks;
 
 import codechicken.nei.guihook.GuiContainerManager;
-import gregtech.api.items.MetaGeneratedItem;
-import gregtech.api.util.GTUtility;
 
 /**
  * Derives a representative color for an ingredient from its sprite, so ports and edges can be
@@ -47,8 +46,9 @@ public final class IngredientColors {
     private static final Map<String, Integer> CACHE = new HashMap<>();
     private static final int ALPHA_OPAQUE_MIN = 128;
 
-    private static final int OUTLINE_DARK = 0xF00A0A0A;
-    private static final int OUTLINE_LIGHT = 0xF0F2F2F2;
+    private static final int UNKNOWN = -1;
+    private static final int NO_TINT = 0xFFFFFF;
+    private static final int RGB_MASK = 0xFFFFFF;
 
     private IngredientColors() {}
 
@@ -65,9 +65,9 @@ public final class IngredientColors {
         } else if (value instanceof final FluidStack fluidStack) {
             rgb = ofFluid(fluidStack);
         } else {
-            rgb = -1;
+            rgb = UNKNOWN;
         }
-        if (rgb == -1) return fallback;
+        if (rgb == UNKNOWN) return fallback;
         return Color.withAlpha(rgb, Color.getAlpha(fallback));
     }
 
@@ -81,7 +81,7 @@ public final class IngredientColors {
             Color.getRed(color) / 255f,
             Color.getGreen(color) / 255f,
             Color.getBlue(color) / 255f);
-        return lum < 0.5f ? OUTLINE_LIGHT : OUTLINE_DARK;
+        return lum < 0.5f ? PlannhColors.EDGE_OUTLINE_LIGHT.getColor() : PlannhColors.EDGE_OUTLINE_DARK.getColor();
     }
 
     private static float luminance(final float r, final float g, final float b) {
@@ -89,7 +89,7 @@ public final class IngredientColors {
     }
 
     private static int ofItem(final ItemStack stack) {
-        if (stack == null || stack.getItem() == null) return -1;
+        if (stack == null || stack.getItem() == null) return UNKNOWN;
         final String key = "item:" + Item.itemRegistry.getNameForObject(stack.getItem()) + ":" + stack.getItemDamage();
         return CACHE.computeIfAbsent(key, k -> {
             try {
@@ -122,8 +122,8 @@ public final class IngredientColors {
                     int tint = item.getColorFromItemStack(stack, pass);
                     // GT material items are grayscale sprites tinted by their custom renderer,
                     // not by getColorFromItemStack; apply the material color to the base pass.
-                    if (pass == 0 && (tint & 0xFFFFFF) == 0xFFFFFF) tint = gtTint;
-                    if ((tint & 0xFFFFFF) != 0xFFFFFF) rgb = multiplyRgb(rgb, tint);
+                    if (pass == 0 && (tint & RGB_MASK) == NO_TINT) tint = gtTint;
+                    if ((tint & RGB_MASK) != NO_TINT) rgb = multiplyRgb(rgb, tint);
                     final long count = modal[1];
                     r += (long) (rgb >> 16 & 0xFF) * count;
                     g += (long) (rgb >> 8 & 0xFF) * count;
@@ -132,18 +132,18 @@ public final class IngredientColors {
                 }
                 if (weight == 0) {
                     PlanNH.LOG.debug("No sprite color derivable for {}, using type fallback", k);
-                    return -1;
+                    return UNKNOWN;
                 }
                 return logColor(k, (int) (r / weight) << 16 | (int) (g / weight) << 8 | (int) (b / weight), "sprite");
             } catch (final Exception e) {
                 PlanNH.LOG.debug("Sprite color derivation failed for {}: {}", k, e.toString());
-                return -1;
+                return UNKNOWN;
             }
         });
     }
 
     private static int ofFluid(final FluidStack fluidStack) {
-        if (fluidStack == null || fluidStack.getFluid() == null) return -1;
+        if (fluidStack == null || fluidStack.getFluid() == null) return UNKNOWN;
         final Fluid fluid = fluidStack.getFluid();
         final String key = "fluid:" + fluid.getName();
         // Manual get/put instead of computeIfAbsent: the display-stack path recurses into
@@ -278,42 +278,31 @@ public final class IngredientColors {
         }
     }
 
-    /**
-     * Chemistry-convention colors for fluids whose in-game color sources are unusable. Hydrogen
-     * defines a white fluid color, its texture region on the stitched atlas is empty, its fluid
-     * display item renders no pixels, and its GT material color is blue - while every player
-     * knows hydrogen as red-pink.
-     */
-    private static final Map<String, Integer> FLUID_CONVENTION_COLORS = Map.of("hydrogen", 0xE05A5A);
-
     private static int computeFluidColor(final FluidStack fluidStack, final Fluid fluid, final String key) {
         try {
-            final Integer convention = FLUID_CONVENTION_COLORS.get(fluid.getName());
-            if (convention != null) return logColor(key, convention, "convention");
-
             // The fluid's own color if it defines one.
             final int tint = fluid.getColor(fluidStack);
-            if ((tint & 0xFFFFFF) != 0xFFFFFF) return logColor(key, tint & 0xFFFFFF, "fluid-color");
+            if ((tint & RGB_MASK) != NO_TINT) return logColor(key, tint & RGB_MASK, "fluid-color");
 
             // Otherwise color it the way NEI displays it: GT's fluid display item carries the
             // exact icon + tint combination the player sees in recipe screens.
-            if (ModularUI.Mods.GT5U.isLoaded()) {
-                final ItemStack display = GTUtility.getFluidDisplayStack(fluidStack, false);
+            if (Compat.GREGTECH.isLoaded) {
+                final ItemStack display = GTHooks.fluidDisplayStack(fluidStack);
                 if (display != null) {
                     final int rgb = ofItem(display);
-                    if (rgb != -1) return logColor(key, rgb, "fluid-display");
+                    if (rgb != UNKNOWN) return logColor(key, rgb, "fluid-display");
                 }
             }
 
             final long[] modal = modalSpriteColor(fluid.getIcon(fluidStack), true);
             if (modal == null) {
                 PlanNH.LOG.debug("No sprite color derivable for {}, using type fallback", key);
-                return -1;
+                return UNKNOWN;
             }
             return logColor(key, (int) modal[0], "fluid-sprite");
         } catch (final Exception e) {
             PlanNH.LOG.debug("Sprite color derivation failed for {}: {}", key, e.toString());
-            return -1;
+            return UNKNOWN;
         }
     }
 
@@ -462,22 +451,16 @@ public final class IngredientColors {
         return rgb;
     }
 
+    /** Bare RGB: an alpha byte here would collide with the UNKNOWN sentinel (0xFFFFFFFF). */
     private static int multiplyRgb(final int rgb, final int tint) {
-        final int r = (rgb >> 16 & 0xFF) * (tint >> 16 & 0xFF) / 255;
-        final int g = (rgb >> 8 & 0xFF) * (tint >> 8 & 0xFF) / 255;
-        final int b = (rgb & 0xFF) * (tint & 0xFF) / 255;
-        return r << 16 | g << 8 | b;
+        return Color.rgb(
+            Color.getRed(rgb) * Color.getRed(tint) / 255,
+            Color.getGreen(rgb) * Color.getGreen(tint) / 255,
+            Color.getBlue(rgb) * Color.getBlue(tint) / 255) & RGB_MASK;
     }
 
     /** GT material color for MetaGeneratedItems (their renderer applies it, so the item API lies). */
     private static int gtMaterialTint(final ItemStack stack) {
-        if (!ModularUI.Mods.GT5U.isLoaded()) return 0xFFFFFF;
-        if (stack.getItem() instanceof final MetaGeneratedItem gtItem) {
-            final short[] rgba = gtItem.getRGBa(stack);
-            if (rgba != null && rgba.length >= 3) {
-                return (rgba[0] & 0xFF) << 16 | (rgba[1] & 0xFF) << 8 | (rgba[2] & 0xFF);
-            }
-        }
-        return 0xFFFFFF;
+        return Compat.GREGTECH.isLoaded ? GTHooks.materialTint(stack) : NO_TINT;
     }
 }

--- a/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
+++ b/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
@@ -17,9 +17,12 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
+import com.cleanroommc.modularui.ModularUI;
 import com.cleanroommc.modularui.utils.Color;
 import com.sbancuz.plannh.PlanNH;
 import com.sbancuz.plannh.data.flowchart.Port;
+
+import gregtech.api.items.MetaGeneratedItem;
 
 /**
  * Derives a representative color for an ingredient from its sprite, so ports and edges can be
@@ -36,16 +39,16 @@ public final class IngredientColors {
     private static final Map<String, Integer> CACHE = new HashMap<>();
     private static final int ALPHA_OPAQUE_MIN = 128;
 
-    /**
-     * Minimum perceived luminance for derived colors. The canvas background is the world, which
-     * can be nearly black at night, so dark sprite colors (e.g. ethenone's navy) are lifted to
-     * stay legible while keeping their hue.
-     */
-    private static final float MIN_LUMINANCE = 0.42f;
+    private static final int OUTLINE_DARK = 0xF00A0A0A;
+    private static final int OUTLINE_LIGHT = 0xF0F2F2F2;
 
     private IngredientColors() {}
 
-    /** Representative ARGB color for the port's ingredient; {@code fallback} (with its alpha) if unknown. */
+    /**
+     * Representative ARGB color for the port's ingredient; {@code fallback} (with its alpha) if
+     * unknown. Colors are true to the sprite - readability on arbitrary backgrounds comes from
+     * pairing them with {@link #outlineFor(int)}.
+     */
     public static int of(final Port<?> port, final int fallback) {
         final Object value = port.getValue();
         final int rgb;
@@ -57,48 +60,24 @@ public final class IngredientColors {
             rgb = -1;
         }
         if (rgb == -1) return fallback;
-        return Color.withAlpha(ensureReadable(rgb), Color.getAlpha(fallback));
+        return Color.withAlpha(rgb, Color.getAlpha(fallback));
     }
 
     /**
-     * Lifts a color to {@link #MIN_LUMINANCE}: first scaled up (preserves saturation), then
-     * blended toward white for whatever channel clipping ate (a saturated navy can't reach the
-     * target by scaling alone).
+     * Contrast outline for a color: light outline under dark colors, dark outline under light
+     * ones. This lets derived colors keep their true luminance (brown stays brown, navy stays
+     * navy) and still read on any world background.
      */
-    private static int ensureReadable(final int rgb) {
-        float r = (rgb >> 16 & 0xFF) / 255f;
-        float g = (rgb >> 8 & 0xFF) / 255f;
-        float b = (rgb & 0xFF) / 255f;
-        float lum = luminance(r, g, b);
-        if (lum >= MIN_LUMINANCE) return rgb;
-        if (lum < 0.004f) {
-            final int v = Math.round(MIN_LUMINANCE * 255);
-            return v << 16 | v << 8 | v;
-        }
-        final float scale = MIN_LUMINANCE / lum;
-        r = Math.min(1f, r * scale);
-        g = Math.min(1f, g * scale);
-        b = Math.min(1f, b * scale);
-        lum = luminance(r, g, b);
-        if (lum < MIN_LUMINANCE) {
-            final float t = (MIN_LUMINANCE - lum) / (1f - lum);
-            r += (1f - r) * t;
-            g += (1f - g) * t;
-            b += (1f - b) * t;
-        }
-        return Math.round(r * 255) << 16 | Math.round(g * 255) << 8 | Math.round(b * 255);
+    public static int outlineFor(final int color) {
+        final float lum = luminance(
+            Color.getRed(color) / 255f,
+            Color.getGreen(color) / 255f,
+            Color.getBlue(color) / 255f);
+        return lum < 0.5f ? OUTLINE_LIGHT : OUTLINE_DARK;
     }
 
     private static float luminance(final float r, final float g, final float b) {
         return 0.299f * r + 0.587f * g + 0.114f * b;
-    }
-
-    /** Mixes the color toward white, for hover rings and highlights. */
-    public static int brighten(final int color, final float factor) {
-        final int r = Color.getRed(color) + Math.round((255 - Color.getRed(color)) * factor);
-        final int g = Color.getGreen(color) + Math.round((255 - Color.getGreen(color)) * factor);
-        final int b = Color.getBlue(color) + Math.round((255 - Color.getBlue(color)) * factor);
-        return Color.argb(r, g, b, Color.getAlpha(color));
     }
 
     private static int ofItem(final ItemStack stack) {
@@ -113,6 +92,7 @@ public final class IngredientColors {
                 final int passes = item.requiresMultipleRenderPasses()
                     ? Math.max(1, item.getRenderPasses(stack.getItemDamage()))
                     : 1;
+                final int gtTint = gtMaterialTint(stack);
                 long r = 0, g = 0, b = 0, weight = 0;
                 for (int pass = 0; pass < passes; pass++) {
                     IIcon icon;
@@ -125,7 +105,10 @@ public final class IngredientColors {
                     final long[] modal = modalSpriteColor(icon, item.getSpriteNumber() == 0);
                     if (modal == null) continue;
                     int rgb = (int) modal[0];
-                    final int tint = item.getColorFromItemStack(stack, pass);
+                    int tint = item.getColorFromItemStack(stack, pass);
+                    // GT material items are grayscale sprites tinted by their custom renderer,
+                    // not by getColorFromItemStack; apply the material color to the base pass.
+                    if (pass == 0 && (tint & 0xFFFFFF) == 0xFFFFFF) tint = gtTint;
                     if ((tint & 0xFFFFFF) != 0xFFFFFF) rgb = multiplyRgb(rgb, tint);
                     final long count = modal[1];
                     r += (long) (rgb >> 16 & 0xFF) * count;
@@ -288,5 +271,17 @@ public final class IngredientColors {
         final int g = (rgb >> 8 & 0xFF) * (tint >> 8 & 0xFF) / 255;
         final int b = (rgb & 0xFF) * (tint & 0xFF) / 255;
         return r << 16 | g << 8 | b;
+    }
+
+    /** GT material color for MetaGeneratedItems (their renderer applies it, so the item API lies). */
+    private static int gtMaterialTint(final ItemStack stack) {
+        if (!ModularUI.Mods.GT5U.isLoaded()) return 0xFFFFFF;
+        if (stack.getItem() instanceof final MetaGeneratedItem gtItem) {
+            final short[] rgba = gtItem.getRGBa(stack);
+            if (rgba != null && rgba.length >= 3) {
+                return (rgba[0] & 0xFF) << 16 | (rgba[1] & 0xFF) << 8 | (rgba[2] & 0xFF);
+            }
+        }
+        return 0xFFFFFF;
     }
 }

--- a/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
+++ b/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
@@ -253,7 +253,11 @@ public final class IngredientColors {
                 final int a = buffer.get(i * 4 + 3) & 0xFF;
                 pixels[i] = a << 24 | r << 16 | g << 8 | b;
             }
-            return modeWithOutlineFallback(pixels, SAMPLE_SIZE, SAMPLE_SIZE);
+            final long[] result = modeWithOutlineFallback(pixels, SAMPLE_SIZE, SAMPLE_SIZE);
+            if (result == null) {
+                PlanNH.LOG.debug("Render sample of {} produced no opaque pixels", stack);
+            }
+            return result;
         } catch (final Exception e) {
             PlanNH.LOG.debug("Render sampling failed for {}: {}", stack, e.toString());
             return null;
@@ -274,8 +278,19 @@ public final class IngredientColors {
         }
     }
 
+    /**
+     * Chemistry-convention colors for fluids whose in-game color sources are unusable. Hydrogen
+     * defines a white fluid color, its texture region on the stitched atlas is empty, its fluid
+     * display item renders no pixels, and its GT material color is blue - while every player
+     * knows hydrogen as red-pink.
+     */
+    private static final Map<String, Integer> FLUID_CONVENTION_COLORS = Map.of("hydrogen", 0xE05A5A);
+
     private static int computeFluidColor(final FluidStack fluidStack, final Fluid fluid, final String key) {
         try {
+            final Integer convention = FLUID_CONVENTION_COLORS.get(fluid.getName());
+            if (convention != null) return logColor(key, convention, "convention");
+
             // The fluid's own color if it defines one.
             final int tint = fluid.getColor(fluidStack);
             if ((tint & 0xFFFFFF) != 0xFFFFFF) return logColor(key, tint & 0xFFFFFF, "fluid-color");
@@ -362,7 +377,10 @@ public final class IngredientColors {
             .getResource(location)
             .getInputStream()) {
             final BufferedImage image = ImageIO.read(in);
-            if (image == null) return null;
+            if (image == null) {
+                PlanNH.LOG.debug("PNG decoded null for icon '{}' at {}", name, location);
+                return null;
+            }
             final int width = image.getWidth();
             // Animated sprites are vertical strips; sample the first frame only.
             final int height = Math.min(image.getHeight(), width);

--- a/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
+++ b/src/main/java/com/sbancuz/plannh/gui/IngredientColors.java
@@ -234,7 +234,9 @@ public final class IngredientColors {
             GL11.glClearColor(0f, 0f, 0f, 0f);
             GL11.glClear(GL11.GL_COLOR_BUFFER_BIT | GL11.GL_DEPTH_BUFFER_BIT);
             GuiContainerManager.enable2DRender();
-            GuiContainerManager.drawItem(0, 0, stack);
+            // Empty quantity string suppresses the white amount text (fluid displays carry
+            // one), which otherwise wins the modal vote over pale sprites.
+            GuiContainerManager.drawItem(0, 0, stack, false, "");
 
             final ByteBuffer buffer = BufferUtils.createByteBuffer(SAMPLE_SIZE * SAMPLE_SIZE * 4);
             GL11.glReadPixels(0, 0, SAMPLE_SIZE, SAMPLE_SIZE, GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, buffer);
@@ -395,9 +397,23 @@ public final class IngredientColors {
                 acc[3] += b;
             }
         }
+        // Saturation-weighted mode: pale sprites (diamond, gases) fragment their gradient over
+        // many near-white bins while pure white concentrates in one, so plain counts pick white.
+        // Weighting by saturation prefers the sprite's characteristic hue; for genuinely
+        // achromatic items (salt, dusts) all bins score equally and the biggest still wins.
         long[] best = null;
+        double bestScore = -1;
         for (final long[] acc : bins.values()) {
-            if (best == null || acc[0] > best[0]) best = acc;
+            final double r = (double) acc[1] / acc[0];
+            final double g = (double) acc[2] / acc[0];
+            final double b = (double) acc[3] / acc[0];
+            final double max = Math.max(r, Math.max(g, b));
+            final double saturation = max <= 0 ? 0 : (max - Math.min(r, Math.min(g, b))) / max;
+            final double score = acc[0] * (0.35 + saturation);
+            if (score > bestScore) {
+                bestScore = score;
+                best = acc;
+            }
         }
         if (best == null) return null;
         final int rgb = (int) (best[1] / best[0]) << 16 | (int) (best[2] / best[0]) << 8 | (int) (best[3] / best[0]);

--- a/src/main/java/com/sbancuz/plannh/gui/PlannhColors.java
+++ b/src/main/java/com/sbancuz/plannh/gui/PlannhColors.java
@@ -42,6 +42,7 @@ public final class PlannhColors {
     // ── Text Colors (opaque) ──
     public static final ColorResource
         TEXT_WHITE   = C.rgb("text_white",   "0xFFFFFF"),
+        TEXT_BLACK   = C.rgb("text_black",   "0x141414"),
         TEXT_LIGHT   = C.rgb("text_light",   "0xCCCCCC"),
         TEXT_MUTED   = C.rgb("text_muted",   "0xAAAAAA"),
         TEXT_DIM     = C.rgb("text_dim",     "0x888888"),

--- a/src/main/java/com/sbancuz/plannh/gui/PlannhColors.java
+++ b/src/main/java/com/sbancuz/plannh/gui/PlannhColors.java
@@ -134,8 +134,6 @@ public final class PlannhColors {
      * the header color is generated (e.g. dynamically from the recipe handler name).
      */
     public static int textOn(final int background) {
-        final float lum = (0.299f * Color.getRed(background) + 0.587f * Color.getGreen(background)
-            + 0.114f * Color.getBlue(background)) / 255f;
-        return lum >= 0.35f ? TEXT_BLACK.getColor() : TEXT_WHITE.getColor();
+        return Color.getLuminance(background) >= 0.35f ? TEXT_BLACK.getColor() : TEXT_WHITE.getColor();
     }
 }

--- a/src/main/java/com/sbancuz/plannh/gui/PlannhColors.java
+++ b/src/main/java/com/sbancuz/plannh/gui/PlannhColors.java
@@ -95,6 +95,11 @@ public final class PlannhColors {
         GRID_LINE      = C.argb("grid_line",       "0x18FFFFFF"),
         GRID_MAJOR     = C.argb("grid_major",      "0x30FFFFFF");
 
+    // ── Ingredient Edge/Pin Contrast Outlines ──
+    public static final ColorResource
+        EDGE_OUTLINE_DARK  = C.argb("edge_outline_dark",   "0xF00A0A0A"),
+        EDGE_OUTLINE_LIGHT = C.argb("edge_outline_light",  "0xF0F2F2F2");
+
     // ── Context Menu ──
     public static final ColorResource
         CONTEXT_BG     = C.argb("context_bg",      "0xE6323237"),
@@ -121,5 +126,16 @@ public final class PlannhColors {
         final int g = (rgb >> 8) & 0xFF;
         final int b = rgb & 0xFF;
         return Color.argb(200, r, g, b);
+    }
+
+    /**
+     * Text color that contrasts with the given background: dark text on light-to-mid
+     * backgrounds, white on dark ones. Keyed to perceived luminance so it stays correct however
+     * the header color is generated (e.g. dynamically from the recipe handler name).
+     */
+    public static int textOn(final int background) {
+        final float lum = (0.299f * Color.getRed(background) + 0.587f * Color.getGreen(background)
+            + 0.114f * Color.getBlue(background)) / 255f;
+        return lum >= 0.35f ? TEXT_BLACK.getColor() : TEXT_WHITE.getColor();
     }
 }

--- a/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
@@ -83,11 +83,8 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
     private static final int GEAR_HIT_BOTTOM = 16;
 
     // Z-translation
-    // Must stay below 300: NEI draws item tooltips at z=300, and nodes above that bury the
-    // tooltip of whatever ingredient is hovered. Node-over-arrow layering is handled by paint
-    // order (arrows draw before node widgets), not by z.
-    private static final int Z_PUSH = 100;
-    private static final int Z_POP = -100;
+    private static final int Z_PUSH = 400;
+    private static final int Z_POP = -400;
 
     // Simple node (no NEI)
     private static final int SIMPLE_TEXT_INSET_X = 4;

--- a/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
@@ -97,7 +97,6 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
     private static final int LEFT_CONTENT_X = 8;
     private static final int THROUGHPUT_GAP = 4;
     private static final int LIST_INDENT = 4;
-    private static final int ROW_HOVER = 0x40FFFFFF;
 
     // Settings panel
     private static final int CONFIG_PANEL_INSET = 2;
@@ -232,8 +231,8 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
     public void draw(final ModularGuiContext context, final WidgetThemeEntry<?> widgetTheme) {
         ensureRecipeHandler();
 
-        // Widget-local mouse while hovered; parked far away otherwise so hover highlights
-        // (NEI's white box, our row highlight) only show on the node actually under the mouse.
+        // Widget-local mouse while hovered; parked far away otherwise so NEI's stack hover box
+        // only shows on the node actually under the mouse.
         if (getContext().isHovered(this)) {
             hoverMx = canvas.getMouseCanvasX() - Math.round(node.x);
             hoverMy = canvas.getMouseCanvasY() - Math.round(node.y);
@@ -452,39 +451,17 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
         GuiDraw.drawText(opsLine.toString(), x, y, 1.0f, PlannhColors.ACCENT_BLUE.getColor(), false);
         y += LINE_H;
 
-        for (final ThroughputRow row : throughputRows()) {
-            final String label = portLabel(row.port(), row.index(), nb, sec, ops, throughput, row.output());
-            if (label == null) continue;
-            if (hoverMy >= row.y() && hoverMy < row.y() + LINE_H && hoverMx >= x && hoverMx < getArea().width - x) {
-                // NEI-style hover box: tells the user the R/U keybinds work on this row.
-                GuiDraw.drawRect(x - 1, row.y() - 2, getArea().width - 2 * x + 2, LINE_H, ROW_HOVER);
-            }
-            final int color = portColor(row.port(), row.output());
-            GuiDraw.drawText(label, x + (row.output() ? LIST_INDENT : 0), row.y(), 1.0f, color, false);
-        }
+        y = drawPortList(x, y, node.inputs, nb, sec, ops, throughput, false);
+        drawPortList(x, y, node.outputs, nb, sec, ops, throughput, true);
     }
 
-    private record ThroughputRow(Port<?> port, int index, boolean output, int y) {}
-
-    /**
-     * The visible throughput rows in draw order with their widget-local y positions - the single
-     * source of row layout for both drawing and R/U hit-testing.
-     */
-    private List<ThroughputRow> throughputRows() {
-        assert neiWidget != null;
-        final List<ThroughputRow> rows = new ArrayList<>();
-        // The first row sits below the ops line.
-        int y = CONTENT_TOP + neiWidget.h + THROUGHPUT_GAP + LINE_H;
-        y = collectRows(node.inputs, false, y, rows);
-        collectRows(node.outputs, true, y, rows);
-        return rows;
-    }
-
-    private int collectRows(final List<Port<?>> ports, final boolean output, int y, final List<ThroughputRow> rows) {
+    private int drawPortList(final int x, int y, final List<Port<?>> ports, final NodeBalance nb, final float sec,
+        final int ops, final int throughput, final boolean output) {
         for (int i = 0; i < ports.size(); i++) {
             final Port<?> port = ports.get(i);
-            if (!hasVisibleAmount(port)) continue;
-            rows.add(new ThroughputRow(port, i, output, y));
+            final String label = portLabel(port, i, nb, sec, ops, throughput, output);
+            if (label == null) continue;
+            GuiDraw.drawText(label, x + (output ? LIST_INDENT : 0), y, 1.0f, portColor(port, output), false);
             y += LINE_H;
         }
         return y;
@@ -801,10 +778,10 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
 
     /**
      * Tells NEI what ingredient the mouse is over, which enables its native recipe/usage
-     * lookups (R/U and bookmark keys) on node contents: the embedded recipe's stacks, the
-     * throughput list rows, and the port pins. Also arms the pending-lookup origin so a recipe
-     * added from the upcoming lookup can be wired back to the originating port; a stack that
-     * maps to no port clears any stale origin.
+     * lookups (R/U and bookmark keys) on node contents: the embedded recipe's stacks and the
+     * port pins. Also arms the pending-lookup origin so a recipe added from the upcoming
+     * lookup can be wired back to the originating port; a stack that maps to no port clears
+     * any stale origin.
      */
     @Override
     @Nullable
@@ -841,9 +818,6 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
         if (neiWidget != null && handlerRef != null) {
             final ItemStack gridStack = neiWidget.getStackMouseOver(mx, my);
             if (gridStack != null) return new IngredientHit(gridStack, portOriginFor(gridStack));
-
-            final ThroughputRow row = throughputRowAt(mx, my);
-            if (row != null) return hitFor(row.port(), row.output(), row.index());
         }
 
         final int out = getOutputPortAt(mx, my);
@@ -881,15 +855,6 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
     private static boolean displayMatches(final Port<?> port, final ItemStack stack) {
         final ItemStack display = port.getDisplayStack();
         return display != null && display.isItemEqual(stack);
-    }
-
-    @Nullable
-    private ThroughputRow throughputRowAt(final int mx, final int my) {
-        if (mx < LEFT_CONTENT_X || mx >= getArea().width - LEFT_CONTENT_X) return null;
-        for (final ThroughputRow row : throughputRows()) {
-            if (my >= row.y() && my < row.y() + LINE_H) return row;
-        }
-        return null;
     }
 
     /** Whether the port draws a throughput row: it holds a value with a positive amount. */

--- a/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
@@ -30,6 +30,7 @@ import com.sbancuz.plannh.data.flowchart.Node;
 import com.sbancuz.plannh.data.flowchart.Port;
 import com.sbancuz.plannh.nei.NodeLookupContext;
 
+import codechicken.nei.PositionedStack;
 import codechicken.nei.drawable.DrawableBuilder;
 import codechicken.nei.drawable.DrawableResource;
 import codechicken.nei.guihook.GuiContainerManager;
@@ -807,8 +808,10 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
         final int my = canvas.getMouseCanvasY() - Math.round(node.y);
 
         if (neiWidget != null && handlerRef != null) {
-            final ItemStack gridStack = neiWidget.getStackMouseOver(mx, my);
-            if (gridStack != null) return new IngredientHit(gridStack, portOriginFor(gridStack));
+            final PositionedStack gridStack = neiWidget.getPositionedStackMouseOver(mx, my);
+            if (gridStack != null) {
+                return new IngredientHit(gridStack.item, portOriginFor(gridStack.item, gridSlotIsInput(gridStack)));
+            }
         }
 
         final int out = getOutputPortAt(mx, my);
@@ -825,18 +828,32 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
         return new IngredientHit(stack, new NodeLookupContext(node.id, output, index));
     }
 
+    /** Whether a hovered grid slot sits on the recipe's input side, by slot position. */
+    private boolean gridSlotIsInput(final PositionedStack hit) {
+        assert handlerRef != null;
+        for (final PositionedStack s : handlerRef.handler.getIngredientStacks(handlerRef.recipeIndex)) {
+            if (s != null && s.relx == hit.relx && s.rely == hit.rely) return true;
+        }
+        return false;
+    }
+
     /**
      * Which port an embedded recipe-grid stack refers to, by forward display-stack comparison
-     * (covers fluids: GT display items encode the fluid in the damage value). Inputs first,
-     * since R on an input is the dominant workflow; null for stacks that are no port's.
+     * (covers fluids: GT display items encode the fluid in the damage value). The hovered
+     * slot's side disambiguates recipes carrying the same ingredient as both input and output;
+     * the opposite side is a fallback for slots that are no port of their own (e.g. catalysts).
      */
     @Nullable
-    private NodeLookupContext portOriginFor(final ItemStack gridStack) {
-        for (int i = 0; i < node.inputs.size(); i++) {
-            if (displayMatches(node.inputs.get(i), gridStack)) return new NodeLookupContext(node.id, false, i);
-        }
-        for (int i = 0; i < node.outputs.size(); i++) {
-            if (displayMatches(node.outputs.get(i), gridStack)) return new NodeLookupContext(node.id, true, i);
+    private NodeLookupContext portOriginFor(final ItemStack gridStack, final boolean inputSide) {
+        final NodeLookupContext sameSide = portMatching(gridStack, !inputSide);
+        return sameSide != null ? sameSide : portMatching(gridStack, inputSide);
+    }
+
+    @Nullable
+    private NodeLookupContext portMatching(final ItemStack stack, final boolean output) {
+        final List<Port<?>> ports = output ? node.outputs : node.inputs;
+        for (int i = 0; i < ports.size(); i++) {
+            if (displayMatches(ports.get(i), stack)) return new NodeLookupContext(node.id, output, i);
         }
         return null;
     }

--- a/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
@@ -12,7 +12,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
-import com.cleanroommc.modularui.ModularUI;
 import com.cleanroommc.modularui.api.widget.Interactable;
 import com.cleanroommc.modularui.drawable.GuiDraw;
 import com.cleanroommc.modularui.integration.recipeviewer.RecipeViewerIngredientProvider;
@@ -20,6 +19,8 @@ import com.cleanroommc.modularui.screen.viewport.ModularGuiContext;
 import com.cleanroommc.modularui.theme.WidgetThemeEntry;
 import com.cleanroommc.modularui.utils.Color;
 import com.cleanroommc.modularui.widget.Widget;
+import com.sbancuz.plannh.Compat;
+import com.sbancuz.plannh.api.PlanAPI;
 import com.sbancuz.plannh.api.RecipePropertyAPI;
 import com.sbancuz.plannh.data.MachineConfig;
 import com.sbancuz.plannh.data.MachineProfile;
@@ -29,7 +30,7 @@ import com.sbancuz.plannh.data.flowchart.Balancer.NodeBalance;
 import com.sbancuz.plannh.data.flowchart.Group;
 import com.sbancuz.plannh.data.flowchart.Node;
 import com.sbancuz.plannh.data.flowchart.Port;
-import com.sbancuz.plannh.nei.NodeLookupContext;
+import com.sbancuz.plannh.data.provider.gregtech.GTHooks;
 
 import codechicken.nei.PositionedStack;
 import codechicken.nei.drawable.DrawableBuilder;
@@ -38,7 +39,6 @@ import codechicken.nei.guihook.GuiContainerManager;
 import codechicken.nei.recipe.GuiCraftingRecipe;
 import codechicken.nei.recipe.NEIRecipeWidget;
 import codechicken.nei.recipe.RecipeHandlerRef;
-import gregtech.api.util.GTUtility;
 import lombok.Getter;
 
 public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Interactable, RecipeViewerIngredientProvider {
@@ -272,7 +272,7 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
                 (float) neiWidget.w / 2 - (float) titleW / 2,
                 TITLE_TEXT_Y,
                 1.0f,
-                PlannhColors.TEXT_BLACK.getColor(),
+                PlannhColors.textOn(titleCol),
                 false);
 
             if (node.machineConfig.hasAnyBoost()) {
@@ -802,7 +802,8 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
         if (result != null) {
             // Remember the origin so a recipe added from the upcoming NEI lookup can be wired
             // back to this node automatically.
-            NodeLookupContext.set(node.id, result);
+            PlanAPI.lookupContext()
+                .set(node.id, result);
         }
         return result;
     }
@@ -881,9 +882,9 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
     @Nullable
     private static ItemStack stackForPort(final Port<?> port) {
         if (port.getType() == RecipePropertyAPI.ITEM) return (ItemStack) port.getValue();
-        if (port.getType() == RecipePropertyAPI.FLUID && ModularUI.Mods.GT5U.isLoaded()) {
+        if (port.getType() == RecipePropertyAPI.FLUID && Compat.GREGTECH.isLoaded) {
             final FluidStack fs = (FluidStack) port.getValue();
-            if (fs != null) return GTUtility.getFluidDisplayStack(fs, false);
+            if (fs != null) return GTHooks.fluidDisplayStack(fs);
         }
         return null;
     }

--- a/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
@@ -271,7 +271,7 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
                 (float) neiWidget.w / 2 - (float) titleW / 2,
                 TITLE_TEXT_Y,
                 1.0f,
-                PlannhColors.TEXT_WHITE.getColor(),
+                PlannhColors.TEXT_BLACK.getColor(),
                 false);
 
             if (node.machineConfig.hasAnyBoost()) {

--- a/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
@@ -291,8 +291,7 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
                 configOpen ? PlannhColors.ACCENT_GREEN.getColor() : PlannhColors.TEXT_DIM.getColor(),
                 false);
 
-            // Passing the real mouse position enables NEI's own hover box on recipe stacks,
-            // signaling that the R/U keybinds work there.
+            // Real mouse position enables NEI's own hover box on recipe stacks.
             neiWidget.draw(hoverMx, hoverMy);
             drawThroughputInfo();
             drawConfigContent();
@@ -777,11 +776,8 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
     }
 
     /**
-     * Tells NEI what ingredient the mouse is over, which enables its native recipe/usage
-     * lookups (R/U and bookmark keys) on node contents: the embedded recipe's stacks and the
-     * port pins. Also arms the pending-lookup origin so a recipe added from the upcoming
-     * lookup can be wired back to the originating port; a stack that maps to no port clears
-     * any stale origin.
+     * Tells NEI what ingredient the mouse is over (enables R/U and bookmarks on the embedded
+     * recipe's stacks and the port pins).
      */
     @Override
     @Nullable
@@ -792,11 +788,6 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
         return hit.stack();
     }
 
-    /**
-     * The ingredient stack under the mouse, if any. Pure query, safe to call every frame (the
-     * screen's hover tooltip does); {@link #getStackForRecipeViewer} is NEI's lookup entry
-     * point and additionally arms the pending-lookup origin.
-     */
     @Nullable
     public ItemStack stackUnderMouse() {
         final IngredientHit hit = ingredientUnderMouse();
@@ -836,10 +827,8 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
 
     /**
      * Which port an embedded recipe-grid stack refers to, by forward display-stack comparison
-     * (GT fluid display items encode their fluid in the damage value, so fluid ports need no
-     * reverse mapping). Inputs first: for recipes carrying an ingredient on both sides, the
-     * dominant workflow is R on an input ("how do I make this"). Null for stacks that are no
-     * port's ingredient.
+     * (covers fluids: GT display items encode the fluid in the damage value). Inputs first,
+     * since R on an input is the dominant workflow; null for stacks that are no port's.
      */
     @Nullable
     private NodeLookupContext portOriginFor(final ItemStack gridStack) {

--- a/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
@@ -19,8 +19,6 @@ import com.cleanroommc.modularui.screen.viewport.ModularGuiContext;
 import com.cleanroommc.modularui.theme.WidgetThemeEntry;
 import com.cleanroommc.modularui.utils.Color;
 import com.cleanroommc.modularui.widget.Widget;
-import com.sbancuz.plannh.Compat;
-import com.sbancuz.plannh.api.PlanAPI;
 import com.sbancuz.plannh.api.RecipePropertyAPI;
 import com.sbancuz.plannh.data.MachineConfig;
 import com.sbancuz.plannh.data.MachineProfile;
@@ -30,9 +28,8 @@ import com.sbancuz.plannh.data.flowchart.Balancer.NodeBalance;
 import com.sbancuz.plannh.data.flowchart.Group;
 import com.sbancuz.plannh.data.flowchart.Node;
 import com.sbancuz.plannh.data.flowchart.Port;
-import com.sbancuz.plannh.data.provider.gregtech.GTHooks;
+import com.sbancuz.plannh.nei.NodeLookupContext;
 
-import codechicken.nei.PositionedStack;
 import codechicken.nei.drawable.DrawableBuilder;
 import codechicken.nei.drawable.DrawableResource;
 import codechicken.nei.guihook.GuiContainerManager;
@@ -412,20 +409,16 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
 
         for (int i = 0; i < node.outputs.size(); i++) {
             final int py = portTopY(i) - half;
-            final Port<?> port = node.outputs.get(i);
-            final int fallback = port.getType() == RecipePropertyAPI.FLUID ? PlannhColors.PIN_FLUID_OUT.getColor()
-                : PlannhColors.PIN_OUTPUT.getColor();
-            final int color = IngredientColors.of(port, fallback);
-            // Dark outline keeps the pin visible against any world background.
+            final int color = node.outputs.get(i)
+                .getPinColor(false);
+            // Contrast outline keeps the pin visible against any world background.
             GuiDraw.drawRect(getArea().width - ps - 1, py - 1, ps + 2, ps + 2, IngredientColors.outlineFor(color));
             GuiDraw.drawRect(getArea().width - ps, py, ps, ps, color);
         }
         for (int i = 0; i < node.inputs.size(); i++) {
             final int py = portTopY(i) - half;
-            final Port<?> port = node.inputs.get(i);
-            final int fallback = port.getType() == RecipePropertyAPI.FLUID ? PlannhColors.PIN_FLUID_IN.getColor()
-                : PlannhColors.PIN_INPUT.getColor();
-            final int color = IngredientColors.of(port, fallback);
+            final int color = node.inputs.get(i)
+                .getPinColor(true);
             GuiDraw.drawRect(-1, py - 1, ps + 2, ps + 2, IngredientColors.outlineFor(color));
             GuiDraw.drawRect(0, py, ps, ps, color);
         }
@@ -459,22 +452,39 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
         GuiDraw.drawText(opsLine.toString(), x, y, 1.0f, PlannhColors.ACCENT_BLUE.getColor(), false);
         y += LINE_H;
 
-        y = drawPortList(x, y, node.inputs, nb, sec, ops, throughput, false);
-        drawPortList(x, y, node.outputs, nb, sec, ops, throughput, true);
+        for (final ThroughputRow row : throughputRows()) {
+            final String label = portLabel(row.port(), row.index(), nb, sec, ops, throughput, row.output());
+            if (label == null) continue;
+            if (hoverMy >= row.y() && hoverMy < row.y() + LINE_H && hoverMx >= x && hoverMx < getArea().width - x) {
+                // NEI-style hover box: tells the user the R/U keybinds work on this row.
+                GuiDraw.drawRect(x - 1, row.y() - 2, getArea().width - 2 * x + 2, LINE_H, ROW_HOVER);
+            }
+            final int color = portColor(row.port(), row.output());
+            GuiDraw.drawText(label, x + (row.output() ? LIST_INDENT : 0), row.y(), 1.0f, color, false);
+        }
     }
 
-    private int drawPortList(final int x, int y, final List<Port<?>> ports, final NodeBalance nb, final float sec,
-        final int ops, final int throughput, final boolean output) {
+    private record ThroughputRow(Port<?> port, int index, boolean output, int y) {}
+
+    /**
+     * The visible throughput rows in draw order with their widget-local y positions - the single
+     * source of row layout for both drawing and R/U hit-testing.
+     */
+    private List<ThroughputRow> throughputRows() {
+        assert neiWidget != null;
+        final List<ThroughputRow> rows = new ArrayList<>();
+        // The first row sits below the ops line.
+        int y = CONTENT_TOP + neiWidget.h + THROUGHPUT_GAP + LINE_H;
+        y = collectRows(node.inputs, false, y, rows);
+        collectRows(node.outputs, true, y, rows);
+        return rows;
+    }
+
+    private int collectRows(final List<Port<?>> ports, final boolean output, int y, final List<ThroughputRow> rows) {
         for (int i = 0; i < ports.size(); i++) {
-            final Port port = ports.get(i);
-            final String label = portLabel(port, i, nb, sec, ops, throughput, output);
-            if (label == null) continue;
-            if (hoverMy >= y && hoverMy < y + LINE_H && hoverMx >= x && hoverMx < getArea().width - x) {
-                // NEI-style hover box: tells the user the R/U keybinds work on this row.
-                GuiDraw.drawRect(x - 1, y - 2, getArea().width - 2 * x + 2, LINE_H, ROW_HOVER);
-            }
-            final int color = portColor(port, output);
-            GuiDraw.drawText(label, x + (output ? LIST_INDENT : 0), y, 1.0f, color, false);
+            final Port<?> port = ports.get(i);
+            if (!hasVisibleAmount(port)) continue;
+            rows.add(new ThroughputRow(port, i, output, y));
             y += LINE_H;
         }
         return y;
@@ -483,9 +493,9 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
     @Nullable
     private String portLabel(final Port<?> port, final int index, final NodeBalance nb, final float sec, final int ops,
         final int throughput, final boolean output) {
+        if (!hasVisibleAmount(port)) return null;
         if (port.getType() == RecipePropertyAPI.ITEM) {
             final ItemStack stack = (ItemStack) port.getValue();
-            if (stack == null || stack.stackSize <= 0) return null;
             final float total = (output ? nb.effectiveOutputs() : nb.effectiveInputs()).containsKey(index) ? output
                 ? nb.effectiveOutputs()
                     .get(index)
@@ -500,7 +510,6 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
         }
         if (port.getType() == RecipePropertyAPI.FLUID) {
             final FluidStack fs = (FluidStack) port.getValue();
-            if (fs == null || fs.amount <= 0) return null;
             final float total;
             if (output) {
                 total = ops * (float) fs.amount * port.getChance() * throughput;
@@ -798,24 +807,28 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
     @Override
     @Nullable
     public ItemStack getStackForRecipeViewer() {
-        final ItemStack result = findStackForRecipeViewer();
+        final ItemStack result = stackUnderMouse();
         if (result != null) {
             // Remember the origin so a recipe added from the upcoming NEI lookup can be wired
             // back to this node automatically.
-            PlanAPI.lookupContext()
-                .set(node.id, result);
+            canvas.setPendingLookup(new NodeLookupContext(node.id, result));
         }
         return result;
     }
 
+    /**
+     * The ingredient stack under the mouse, if any. Pure query, safe to call every frame (the
+     * screen's hover tooltip does); {@link #getStackForRecipeViewer} is NEI's lookup entry point
+     * and additionally arms the pending-lookup origin.
+     */
     @Nullable
-    private ItemStack findStackForRecipeViewer() {
+    public ItemStack stackUnderMouse() {
         // World-space widget-local mouse; independent of whatever viewport state NEI calls us in.
         final int mx = canvas.getMouseCanvasX() - Math.round(node.x);
         final int my = canvas.getMouseCanvasY() - Math.round(node.y);
 
         if (neiWidget != null && handlerRef != null) {
-            final ItemStack recipeStack = recipeStackAt(mx, my);
+            final ItemStack recipeStack = neiWidget.getStackMouseOver(mx, my);
             if (recipeStack != null) return recipeStack;
 
             final ItemStack rowStack = throughputRowStackAt(mx, my);
@@ -823,51 +836,26 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
         }
 
         final int out = getOutputPortAt(mx, my);
-        if (out >= 0) return stackForPort(node.outputs.get(out));
+        if (out >= 0) return node.outputs.get(out)
+            .getDisplayStack();
         final int in = getInputPortAt(mx, my);
-        if (in >= 0) return stackForPort(node.inputs.get(in));
-        return null;
-    }
-
-    @Nullable
-    private ItemStack recipeStackAt(final int mx, final int my) {
-        assert neiWidget != null && handlerRef != null;
-        final int lx = mx - neiWidget.x;
-        final int ly = my - neiWidget.y
-            - neiWidget.getHandlerInfo()
-                .getYShift();
-        final int idx = handlerRef.recipeIndex;
-        for (final PositionedStack stack : handlerRef.handler.getIngredientStacks(idx)) {
-            if (stack != null && stack.contains(lx, ly)) return stack.item;
-        }
-        for (final PositionedStack stack : handlerRef.handler.getOtherStacks(idx)) {
-            if (stack != null && stack.contains(lx, ly)) return stack.item;
-        }
-        final PositionedStack result = handlerRef.handler.getResultStack(idx);
-        if (result != null && result.contains(lx, ly)) return result.item;
+        if (in >= 0) return node.inputs.get(in)
+            .getDisplayStack();
         return null;
     }
 
     @Nullable
     private ItemStack throughputRowStackAt(final int mx, final int my) {
-        assert neiWidget != null;
         if (mx < LEFT_CONTENT_X || mx >= getArea().width - LEFT_CONTENT_X) return null;
-        // Mirror drawThroughputInfo's row sequence: ops line, inputs, then outputs.
-        int y = CONTENT_TOP + neiWidget.h + THROUGHPUT_GAP + LINE_H;
-        for (final Port<?> port : node.inputs) {
-            if (!hasVisibleRow(port)) continue;
-            if (my >= y && my < y + LINE_H) return stackForPort(port);
-            y += LINE_H;
-        }
-        for (final Port<?> port : node.outputs) {
-            if (!hasVisibleRow(port)) continue;
-            if (my >= y && my < y + LINE_H) return stackForPort(port);
-            y += LINE_H;
+        for (final ThroughputRow row : throughputRows()) {
+            if (my >= row.y() && my < row.y() + LINE_H) return row.port()
+                .getDisplayStack();
         }
         return null;
     }
 
-    private static boolean hasVisibleRow(final Port<?> port) {
+    /** Whether the port draws a throughput row: it holds a value with a positive amount. */
+    private static boolean hasVisibleAmount(final Port<?> port) {
         if (port.getType() == RecipePropertyAPI.ITEM) {
             final ItemStack stack = (ItemStack) port.getValue();
             return stack != null && stack.stackSize > 0;
@@ -879,13 +867,4 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
         return false;
     }
 
-    @Nullable
-    private static ItemStack stackForPort(final Port<?> port) {
-        if (port.getType() == RecipePropertyAPI.ITEM) return (ItemStack) port.getValue();
-        if (port.getType() == RecipePropertyAPI.FLUID && Compat.GREGTECH.isLoaded) {
-            final FluidStack fs = (FluidStack) port.getValue();
-            if (fs != null) return GTHooks.fluidDisplayStack(fs);
-        }
-        return null;
-    }
 }

--- a/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
@@ -802,54 +802,92 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
     /**
      * Tells NEI what ingredient the mouse is over, which enables its native recipe/usage
      * lookups (R/U and bookmark keys) on node contents: the embedded recipe's stacks, the
-     * throughput list rows, and the port pins.
+     * throughput list rows, and the port pins. Also arms the pending-lookup origin so a recipe
+     * added from the upcoming lookup can be wired back to the originating port; a stack that
+     * maps to no port clears any stale origin.
      */
     @Override
     @Nullable
     public ItemStack getStackForRecipeViewer() {
-        final ItemStack result = stackUnderMouse();
-        if (result != null) {
-            // Remember the origin so a recipe added from the upcoming NEI lookup can be wired
-            // back to this node automatically.
-            canvas.setPendingLookup(new NodeLookupContext(node.id, result));
-        }
-        return result;
+        final IngredientHit hit = ingredientUnderMouse();
+        if (hit == null) return null;
+        canvas.setPendingLookup(hit.origin());
+        return hit.stack();
     }
 
     /**
      * The ingredient stack under the mouse, if any. Pure query, safe to call every frame (the
-     * screen's hover tooltip does); {@link #getStackForRecipeViewer} is NEI's lookup entry point
-     * and additionally arms the pending-lookup origin.
+     * screen's hover tooltip does); {@link #getStackForRecipeViewer} is NEI's lookup entry
+     * point and additionally arms the pending-lookup origin.
      */
     @Nullable
     public ItemStack stackUnderMouse() {
+        final IngredientHit hit = ingredientUnderMouse();
+        return hit == null ? null : hit.stack();
+    }
+
+    /**
+     * A hovered ingredient: the display stack NEI operates on, plus the port it came from -
+     * null when an embedded grid stack is no port's ingredient (catalysts, machine items).
+     */
+    private record IngredientHit(ItemStack stack, @Nullable NodeLookupContext origin) {}
+
+    @Nullable
+    private IngredientHit ingredientUnderMouse() {
         // World-space widget-local mouse; independent of whatever viewport state NEI calls us in.
         final int mx = canvas.getMouseCanvasX() - Math.round(node.x);
         final int my = canvas.getMouseCanvasY() - Math.round(node.y);
 
         if (neiWidget != null && handlerRef != null) {
-            final ItemStack recipeStack = neiWidget.getStackMouseOver(mx, my);
-            if (recipeStack != null) return recipeStack;
+            final ItemStack gridStack = neiWidget.getStackMouseOver(mx, my);
+            if (gridStack != null) return new IngredientHit(gridStack, portOriginFor(gridStack));
 
-            final ItemStack rowStack = throughputRowStackAt(mx, my);
-            if (rowStack != null) return rowStack;
+            final ThroughputRow row = throughputRowAt(mx, my);
+            if (row != null) return hitFor(row.port(), row.output(), row.index());
         }
 
         final int out = getOutputPortAt(mx, my);
-        if (out >= 0) return node.outputs.get(out)
-            .getDisplayStack();
+        if (out >= 0) return hitFor(node.outputs.get(out), true, out);
         final int in = getInputPortAt(mx, my);
-        if (in >= 0) return node.inputs.get(in)
-            .getDisplayStack();
+        if (in >= 0) return hitFor(node.inputs.get(in), false, in);
         return null;
     }
 
     @Nullable
-    private ItemStack throughputRowStackAt(final int mx, final int my) {
+    private IngredientHit hitFor(final Port<?> port, final boolean output, final int index) {
+        final ItemStack stack = port.getDisplayStack();
+        if (stack == null) return null;
+        return new IngredientHit(stack, new NodeLookupContext(node.id, output, index));
+    }
+
+    /**
+     * Which port an embedded recipe-grid stack refers to, by forward display-stack comparison
+     * (GT fluid display items encode their fluid in the damage value, so fluid ports need no
+     * reverse mapping). Inputs first: for recipes carrying an ingredient on both sides, the
+     * dominant workflow is R on an input ("how do I make this"). Null for stacks that are no
+     * port's ingredient.
+     */
+    @Nullable
+    private NodeLookupContext portOriginFor(final ItemStack gridStack) {
+        for (int i = 0; i < node.inputs.size(); i++) {
+            if (displayMatches(node.inputs.get(i), gridStack)) return new NodeLookupContext(node.id, false, i);
+        }
+        for (int i = 0; i < node.outputs.size(); i++) {
+            if (displayMatches(node.outputs.get(i), gridStack)) return new NodeLookupContext(node.id, true, i);
+        }
+        return null;
+    }
+
+    private static boolean displayMatches(final Port<?> port, final ItemStack stack) {
+        final ItemStack display = port.getDisplayStack();
+        return display != null && display.isItemEqual(stack);
+    }
+
+    @Nullable
+    private ThroughputRow throughputRowAt(final int mx, final int my) {
         if (mx < LEFT_CONTENT_X || mx >= getArea().width - LEFT_CONTENT_X) return null;
         for (final ThroughputRow row : throughputRows()) {
-            if (my >= row.y() && my < row.y() + LINE_H) return row.port()
-                .getDisplayStack();
+            if (my >= row.y() && my < row.y() + LINE_H) return row;
         }
         return null;
     }

--- a/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
@@ -99,7 +99,6 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
     private static final int LEFT_CONTENT_X = 8;
     private static final int THROUGHPUT_GAP = 4;
     private static final int LIST_INDENT = 4;
-    private static final int PIN_OUTLINE = 0xE0141414;
     private static final int ROW_HOVER = 0x40FFFFFF;
 
     // Settings panel
@@ -417,7 +416,7 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
                 : PlannhColors.PIN_OUTPUT.getColor();
             final int color = IngredientColors.of(port, fallback);
             // Dark outline keeps the pin visible against any world background.
-            GuiDraw.drawRect(getArea().width - ps - 1, py - 1, ps + 2, ps + 2, PIN_OUTLINE);
+            GuiDraw.drawRect(getArea().width - ps - 1, py - 1, ps + 2, ps + 2, IngredientColors.outlineFor(color));
             GuiDraw.drawRect(getArea().width - ps, py, ps, ps, color);
         }
         for (int i = 0; i < node.inputs.size(); i++) {
@@ -426,7 +425,7 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
             final int fallback = port.getType() == RecipePropertyAPI.FLUID ? PlannhColors.PIN_FLUID_IN.getColor()
                 : PlannhColors.PIN_INPUT.getColor();
             final int color = IngredientColors.of(port, fallback);
-            GuiDraw.drawRect(-1, py - 1, ps + 2, ps + 2, PIN_OUTLINE);
+            GuiDraw.drawRect(-1, py - 1, ps + 2, ps + 2, IngredientColors.outlineFor(color));
             GuiDraw.drawRect(0, py, ps, ps, color);
         }
     }

--- a/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
@@ -83,8 +83,11 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
     private static final int GEAR_HIT_BOTTOM = 16;
 
     // Z-translation
-    private static final int Z_PUSH = 400;
-    private static final int Z_POP = -400;
+    // Must stay below 300: NEI draws item tooltips at z=300, and nodes above that bury the
+    // tooltip of whatever ingredient is hovered. Node-over-arrow layering is handled by paint
+    // order (arrows draw before node widgets), not by z.
+    private static final int Z_PUSH = 100;
+    private static final int Z_POP = -100;
 
     // Simple node (no NEI)
     private static final int SIMPLE_TEXT_INSET_X = 4;

--- a/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
@@ -29,6 +29,7 @@ import com.sbancuz.plannh.data.flowchart.Balancer.NodeBalance;
 import com.sbancuz.plannh.data.flowchart.Group;
 import com.sbancuz.plannh.data.flowchart.Node;
 import com.sbancuz.plannh.data.flowchart.Port;
+import com.sbancuz.plannh.nei.NodeLookupContext;
 
 import codechicken.nei.PositionedStack;
 import codechicken.nei.drawable.DrawableBuilder;
@@ -797,6 +798,17 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
     @Override
     @Nullable
     public ItemStack getStackForRecipeViewer() {
+        final ItemStack result = findStackForRecipeViewer();
+        if (result != null) {
+            // Remember the origin so a recipe added from the upcoming NEI lookup can be wired
+            // back to this node automatically.
+            NodeLookupContext.set(node.id, result);
+        }
+        return result;
+    }
+
+    @Nullable
+    private ItemStack findStackForRecipeViewer() {
         // World-space widget-local mouse; independent of whatever viewport state NEI calls us in.
         final int mx = canvas.getMouseCanvasX() - Math.round(node.x);
         final int my = canvas.getMouseCanvasY() - Math.round(node.y);

--- a/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
@@ -12,8 +12,10 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
+import com.cleanroommc.modularui.ModularUI;
 import com.cleanroommc.modularui.api.widget.Interactable;
 import com.cleanroommc.modularui.drawable.GuiDraw;
+import com.cleanroommc.modularui.integration.recipeviewer.RecipeViewerIngredientProvider;
 import com.cleanroommc.modularui.screen.viewport.ModularGuiContext;
 import com.cleanroommc.modularui.theme.WidgetThemeEntry;
 import com.cleanroommc.modularui.utils.Color;
@@ -28,15 +30,17 @@ import com.sbancuz.plannh.data.flowchart.Group;
 import com.sbancuz.plannh.data.flowchart.Node;
 import com.sbancuz.plannh.data.flowchart.Port;
 
+import codechicken.nei.PositionedStack;
 import codechicken.nei.drawable.DrawableBuilder;
 import codechicken.nei.drawable.DrawableResource;
 import codechicken.nei.guihook.GuiContainerManager;
 import codechicken.nei.recipe.GuiCraftingRecipe;
 import codechicken.nei.recipe.NEIRecipeWidget;
 import codechicken.nei.recipe.RecipeHandlerRef;
+import gregtech.api.util.GTUtility;
 import lombok.Getter;
 
-public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Interactable {
+public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Interactable, RecipeViewerIngredientProvider {
 
     private static final int BASE_W = 120;
     private static final int BASE_H = 80;
@@ -392,35 +396,23 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
 
         for (int i = 0; i < node.outputs.size(); i++) {
             final int py = portTopY(i) - half;
-            final Port port = node.outputs.get(i);
-            if (port.getType() == RecipePropertyAPI.FLUID) {
-                GuiDraw.drawRect(
-                    getArea().width - ps - 1,
-                    py - 1,
-                    ps + 2,
-                    ps + 2,
-                    PlannhColors.PIN_FLUID_OUT_H.getColor());
-                GuiDraw.drawRect(getArea().width - ps, py, ps, ps, PlannhColors.PIN_FLUID_OUT.getColor());
-            } else {
-                GuiDraw.drawRect(
-                    getArea().width - ps - 1,
-                    py - 1,
-                    ps + 2,
-                    ps + 2,
-                    PlannhColors.PIN_OUTPUT_HOVER.getColor());
-                GuiDraw.drawRect(getArea().width - ps, py, ps, ps, PlannhColors.PIN_OUTPUT.getColor());
-            }
+            final Port<?> port = node.outputs.get(i);
+            final int fallback = port.getType() == RecipePropertyAPI.FLUID ? PlannhColors.PIN_FLUID_OUT.getColor()
+                : PlannhColors.PIN_OUTPUT.getColor();
+            final int color = IngredientColors.of(port, fallback);
+            final int ring = Color.withAlpha(IngredientColors.brighten(color, 0.5f), 0x3C);
+            GuiDraw.drawRect(getArea().width - ps - 1, py - 1, ps + 2, ps + 2, ring);
+            GuiDraw.drawRect(getArea().width - ps, py, ps, ps, color);
         }
         for (int i = 0; i < node.inputs.size(); i++) {
             final int py = portTopY(i) - half;
-            final Port port = node.inputs.get(i);
-            if (port.getType() == RecipePropertyAPI.FLUID) {
-                GuiDraw.drawRect(-1, py - 1, ps + 2, ps + 2, PlannhColors.PIN_FLUID_IN_H.getColor());
-                GuiDraw.drawRect(0, py, ps, ps, PlannhColors.PIN_FLUID_IN.getColor());
-            } else {
-                GuiDraw.drawRect(-1, py - 1, ps + 2, ps + 2, PlannhColors.PIN_INPUT_HOVER.getColor());
-                GuiDraw.drawRect(0, py, ps, ps, PlannhColors.PIN_INPUT.getColor());
-            }
+            final Port<?> port = node.inputs.get(i);
+            final int fallback = port.getType() == RecipePropertyAPI.FLUID ? PlannhColors.PIN_FLUID_IN.getColor()
+                : PlannhColors.PIN_INPUT.getColor();
+            final int color = IngredientColors.of(port, fallback);
+            final int ring = Color.withAlpha(IngredientColors.brighten(color, 0.5f), 0x3C);
+            GuiDraw.drawRect(-1, py - 1, ps + 2, ps + 2, ring);
+            GuiDraw.drawRect(0, py, ps, ps, color);
         }
     }
 
@@ -777,5 +769,92 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
                 return;
             }
         }
+    }
+
+    /**
+     * Tells NEI what ingredient the mouse is over, which enables its native recipe/usage
+     * lookups (R/U and bookmark keys) on node contents: the embedded recipe's stacks, the
+     * throughput list rows, and the port pins.
+     */
+    @Override
+    @Nullable
+    public ItemStack getStackForRecipeViewer() {
+        // World-space widget-local mouse; independent of whatever viewport state NEI calls us in.
+        final int mx = canvas.getMouseCanvasX() - Math.round(node.x);
+        final int my = canvas.getMouseCanvasY() - Math.round(node.y);
+
+        if (neiWidget != null && handlerRef != null) {
+            final ItemStack recipeStack = recipeStackAt(mx, my);
+            if (recipeStack != null) return recipeStack;
+
+            final ItemStack rowStack = throughputRowStackAt(mx, my);
+            if (rowStack != null) return rowStack;
+        }
+
+        final int out = getOutputPortAt(mx, my);
+        if (out >= 0) return stackForPort(node.outputs.get(out));
+        final int in = getInputPortAt(mx, my);
+        if (in >= 0) return stackForPort(node.inputs.get(in));
+        return null;
+    }
+
+    @Nullable
+    private ItemStack recipeStackAt(final int mx, final int my) {
+        assert neiWidget != null && handlerRef != null;
+        final int lx = mx - neiWidget.x;
+        final int ly = my - neiWidget.y
+            - neiWidget.getHandlerInfo()
+                .getYShift();
+        final int idx = handlerRef.recipeIndex;
+        for (final PositionedStack stack : handlerRef.handler.getIngredientStacks(idx)) {
+            if (stack != null && stack.contains(lx, ly)) return stack.item;
+        }
+        for (final PositionedStack stack : handlerRef.handler.getOtherStacks(idx)) {
+            if (stack != null && stack.contains(lx, ly)) return stack.item;
+        }
+        final PositionedStack result = handlerRef.handler.getResultStack(idx);
+        if (result != null && result.contains(lx, ly)) return result.item;
+        return null;
+    }
+
+    @Nullable
+    private ItemStack throughputRowStackAt(final int mx, final int my) {
+        assert neiWidget != null;
+        if (mx < LEFT_CONTENT_X || mx >= getArea().width - LEFT_CONTENT_X) return null;
+        // Mirror drawThroughputInfo's row sequence: ops line, inputs, then outputs.
+        int y = CONTENT_TOP + neiWidget.h + THROUGHPUT_GAP + LINE_H;
+        for (final Port<?> port : node.inputs) {
+            if (!hasVisibleRow(port)) continue;
+            if (my >= y && my < y + LINE_H) return stackForPort(port);
+            y += LINE_H;
+        }
+        for (final Port<?> port : node.outputs) {
+            if (!hasVisibleRow(port)) continue;
+            if (my >= y && my < y + LINE_H) return stackForPort(port);
+            y += LINE_H;
+        }
+        return null;
+    }
+
+    private static boolean hasVisibleRow(final Port<?> port) {
+        if (port.getType() == RecipePropertyAPI.ITEM) {
+            final ItemStack stack = (ItemStack) port.getValue();
+            return stack != null && stack.stackSize > 0;
+        }
+        if (port.getType() == RecipePropertyAPI.FLUID) {
+            final FluidStack fs = (FluidStack) port.getValue();
+            return fs != null && fs.amount > 0;
+        }
+        return false;
+    }
+
+    @Nullable
+    private static ItemStack stackForPort(final Port<?> port) {
+        if (port.getType() == RecipePropertyAPI.ITEM) return (ItemStack) port.getValue();
+        if (port.getType() == RecipePropertyAPI.FLUID && ModularUI.Mods.GT5U.isLoaded()) {
+            final FluidStack fs = (FluidStack) port.getValue();
+            if (fs != null) return GTUtility.getFluidDisplayStack(fs, false);
+        }
+        return null;
     }
 }

--- a/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
@@ -99,6 +99,8 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
     private static final int LEFT_CONTENT_X = 8;
     private static final int THROUGHPUT_GAP = 4;
     private static final int LIST_INDENT = 4;
+    private static final int PIN_OUTLINE = 0xE0141414;
+    private static final int ROW_HOVER = 0x40FFFFFF;
 
     // Settings panel
     private static final int CONFIG_PANEL_INSET = 2;
@@ -139,6 +141,8 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
     private long lastHandlerUpdate = 0;
     private boolean configOpen = false;
     private final List<ClickZone> configZones = new ArrayList<>();
+    private int hoverMx = -10000;
+    private int hoverMy = -10000;
 
     private record ClickZone(int ux1, int uy1, int ux2, int uy2, Runnable action) {
 
@@ -231,6 +235,16 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
     public void draw(final ModularGuiContext context, final WidgetThemeEntry<?> widgetTheme) {
         ensureRecipeHandler();
 
+        // Widget-local mouse while hovered; parked far away otherwise so hover highlights
+        // (NEI's white box, our row highlight) only show on the node actually under the mouse.
+        if (getContext().isHovered(this)) {
+            hoverMx = canvas.getMouseCanvasX() - Math.round(node.x);
+            hoverMy = canvas.getMouseCanvasY() - Math.round(node.y);
+        } else {
+            hoverMx = -10000;
+            hoverMy = -10000;
+        }
+
         if (neiWidget != null && handlerRef != null) {
             final long now = Minecraft.getSystemTime();
             if (now - lastHandlerUpdate > NEI_HANDLER_THROTTLE_MS) {
@@ -281,7 +295,9 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
                 configOpen ? PlannhColors.ACCENT_GREEN.getColor() : PlannhColors.TEXT_DIM.getColor(),
                 false);
 
-            neiWidget.draw(CONTENT_INSET, CONTENT_TOP);
+            // Passing the real mouse position enables NEI's own hover box on recipe stacks,
+            // signaling that the R/U keybinds work there.
+            neiWidget.draw(hoverMx, hoverMy);
             drawThroughputInfo();
             drawConfigContent();
             drawCloseButtonPixel(getArea().width, getArea().height);
@@ -400,8 +416,8 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
             final int fallback = port.getType() == RecipePropertyAPI.FLUID ? PlannhColors.PIN_FLUID_OUT.getColor()
                 : PlannhColors.PIN_OUTPUT.getColor();
             final int color = IngredientColors.of(port, fallback);
-            final int ring = Color.withAlpha(IngredientColors.brighten(color, 0.5f), 0x3C);
-            GuiDraw.drawRect(getArea().width - ps - 1, py - 1, ps + 2, ps + 2, ring);
+            // Dark outline keeps the pin visible against any world background.
+            GuiDraw.drawRect(getArea().width - ps - 1, py - 1, ps + 2, ps + 2, PIN_OUTLINE);
             GuiDraw.drawRect(getArea().width - ps, py, ps, ps, color);
         }
         for (int i = 0; i < node.inputs.size(); i++) {
@@ -410,8 +426,7 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
             final int fallback = port.getType() == RecipePropertyAPI.FLUID ? PlannhColors.PIN_FLUID_IN.getColor()
                 : PlannhColors.PIN_INPUT.getColor();
             final int color = IngredientColors.of(port, fallback);
-            final int ring = Color.withAlpha(IngredientColors.brighten(color, 0.5f), 0x3C);
-            GuiDraw.drawRect(-1, py - 1, ps + 2, ps + 2, ring);
+            GuiDraw.drawRect(-1, py - 1, ps + 2, ps + 2, PIN_OUTLINE);
             GuiDraw.drawRect(0, py, ps, ps, color);
         }
     }
@@ -454,6 +469,10 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
             final Port port = ports.get(i);
             final String label = portLabel(port, i, nb, sec, ops, throughput, output);
             if (label == null) continue;
+            if (hoverMy >= y && hoverMy < y + LINE_H && hoverMx >= x && hoverMx < getArea().width - x) {
+                // NEI-style hover box: tells the user the R/U keybinds work on this row.
+                GuiDraw.drawRect(x - 1, y - 2, getArea().width - 2 * x + 2, LINE_H, ROW_HOVER);
+            }
             final int color = portColor(port, output);
             GuiDraw.drawText(label, x + (output ? LIST_INDENT : 0), y, 1.0f, color, false);
             y += LINE_H;

--- a/src/main/java/com/sbancuz/plannh/nei/NodeLookupContext.java
+++ b/src/main/java/com/sbancuz/plannh/nei/NodeLookupContext.java
@@ -2,43 +2,17 @@ package com.sbancuz.plannh.nei;
 
 import java.util.UUID;
 
-import javax.annotation.Nullable;
-
 import net.minecraft.item.ItemStack;
 
 /**
- * Remembers which node (and which of its ingredients) the user last ran an NEI recipe/usage
- * lookup from, so a recipe added from that lookup can be wired back to the originating node
- * automatically. Owned by {@link com.sbancuz.plannh.api.PlanAPI#lookupContext()}: the writer
- * (the node widget answering the R/U keybind) and the reader (the NEI overlay handler) have no
- * reference to each other and NEI constructs its handlers itself, so the shared session instance
- * lives on the API facade.
+ * The node (and which of its ingredients) the user last ran an NEI recipe/usage lookup from, so
+ * a recipe added from that lookup can be wired back to the originating node. Held as a one-shot
+ * pending value on the canvas ({@code CanvasWidget#consumePendingLookup}), whose lifetime bounds
+ * the lookup's.
  *
  * <p>
  * Fluids are covered because NEI's lookup currency is the ItemStack: a fluid port answers R/U
- * with its GT fluid display stack, and the overlay handler translates display stacks back to
- * fluids when matching ports.
+ * with its GT fluid display stack, and ports translate display stacks back when matching
+ * ({@code Port#matchesLookup}).
  */
-public final class NodeLookupContext {
-
-    /** The node and ingredient an NEI lookup started from. */
-    public record Origin(UUID nodeId, ItemStack stack) {}
-
-    @Nullable
-    private Origin origin;
-
-    public void set(final UUID originNodeId, final ItemStack lookupStack) {
-        origin = new Origin(originNodeId, lookupStack);
-    }
-
-    /**
-     * Returns the pending origin and clears it: a lookup wires at most one added recipe, so a
-     * stale origin can never auto-connect something added much later in the session.
-     */
-    @Nullable
-    public Origin consume() {
-        final Origin result = origin;
-        origin = null;
-        return result;
-    }
-}
+public record NodeLookupContext(UUID nodeId, ItemStack stack) {}

--- a/src/main/java/com/sbancuz/plannh/nei/NodeLookupContext.java
+++ b/src/main/java/com/sbancuz/plannh/nei/NodeLookupContext.java
@@ -1,0 +1,37 @@
+package com.sbancuz.plannh.nei;
+
+import java.util.UUID;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.item.ItemStack;
+
+/**
+ * Remembers which node (and which of its ingredients) the user last ran an NEI recipe/usage
+ * lookup from, so a recipe added from that lookup can be wired back to the originating node
+ * automatically.
+ */
+public final class NodeLookupContext {
+
+    @Nullable
+    private static UUID nodeId;
+    @Nullable
+    private static ItemStack stack;
+
+    private NodeLookupContext() {}
+
+    public static void set(final UUID originNodeId, final ItemStack lookupStack) {
+        nodeId = originNodeId;
+        stack = lookupStack;
+    }
+
+    @Nullable
+    public static UUID nodeId() {
+        return nodeId;
+    }
+
+    @Nullable
+    public static ItemStack stack() {
+        return stack;
+    }
+}

--- a/src/main/java/com/sbancuz/plannh/nei/NodeLookupContext.java
+++ b/src/main/java/com/sbancuz/plannh/nei/NodeLookupContext.java
@@ -2,17 +2,16 @@ package com.sbancuz.plannh.nei;
 
 import java.util.UUID;
 
-import net.minecraft.item.ItemStack;
-
 /**
- * The node (and which of its ingredients) the user last ran an NEI recipe/usage lookup from, so
- * a recipe added from that lookup can be wired back to the originating node. Held as a one-shot
- * pending value on the canvas ({@code CanvasWidget#consumePendingLookup}), whose lifetime bounds
- * the lookup's.
+ * The port the user last ran an NEI recipe/usage lookup from (R/U on a node's pin, throughput
+ * row, or embedded recipe stack), so a recipe added from that lookup can be wired back to it.
+ * Held as a one-shot pending value on the canvas ({@code CanvasWidget#consumePendingLookup}),
+ * whose lifetime bounds the lookup's.
  *
  * <p>
- * Fluids are covered because NEI's lookup currency is the ItemStack: a fluid port answers R/U
- * with its GT fluid display stack, and ports translate display stacks back when matching
- * ({@code Port#matchesLookup}).
+ * Deliberately a port handle, not an ItemStack: stacks are NEI's lookup currency and stay at
+ * that boundary ({@code RecipeNodeWidget#getStackForRecipeViewer}). Wiring back happens in
+ * port/value space via {@code Port#canConnect}, which every resource type supports without
+ * ItemStack reverse-mapping.
  */
-public record NodeLookupContext(UUID nodeId, ItemStack stack) {}
+public record NodeLookupContext(UUID nodeId, boolean output, int portIndex) {}

--- a/src/main/java/com/sbancuz/plannh/nei/NodeLookupContext.java
+++ b/src/main/java/com/sbancuz/plannh/nei/NodeLookupContext.java
@@ -3,8 +3,8 @@ package com.sbancuz.plannh.nei;
 import java.util.UUID;
 
 /**
- * The port the user last ran an NEI recipe/usage lookup from (R/U on a node's pin, throughput
- * row, or embedded recipe stack), so a recipe added from that lookup can be wired back to it.
+ * The port the user last ran an NEI recipe/usage lookup from (R/U on a node's pin or embedded
+ * recipe stack), so a recipe added from that lookup can be wired back to it.
  * Held as a one-shot pending value on the canvas ({@code CanvasWidget#consumePendingLookup}),
  * whose lifetime bounds the lookup's.
  *

--- a/src/main/java/com/sbancuz/plannh/nei/NodeLookupContext.java
+++ b/src/main/java/com/sbancuz/plannh/nei/NodeLookupContext.java
@@ -3,15 +3,7 @@ package com.sbancuz.plannh.nei;
 import java.util.UUID;
 
 /**
- * The port the user last ran an NEI recipe/usage lookup from (R/U on a node's pin or embedded
- * recipe stack), so a recipe added from that lookup can be wired back to it.
- * Held as a one-shot pending value on the canvas ({@code CanvasWidget#consumePendingLookup}),
- * whose lifetime bounds the lookup's.
- *
- * <p>
- * Deliberately a port handle, not an ItemStack: stacks are NEI's lookup currency and stay at
- * that boundary ({@code RecipeNodeWidget#getStackForRecipeViewer}). Wiring back happens in
- * port/value space via {@code Port#canConnect}, which every resource type supports without
- * ItemStack reverse-mapping.
+ * The port the user last ran an NEI recipe/usage lookup from.
+ * ItemStacks stay at the NEI boundary and wiring happens via {@code Port#canConnect}.
  */
 public record NodeLookupContext(UUID nodeId, boolean output, int portIndex) {}

--- a/src/main/java/com/sbancuz/plannh/nei/NodeLookupContext.java
+++ b/src/main/java/com/sbancuz/plannh/nei/NodeLookupContext.java
@@ -9,29 +9,36 @@ import net.minecraft.item.ItemStack;
 /**
  * Remembers which node (and which of its ingredients) the user last ran an NEI recipe/usage
  * lookup from, so a recipe added from that lookup can be wired back to the originating node
- * automatically.
+ * automatically. Owned by {@link com.sbancuz.plannh.api.PlanAPI#lookupContext()}: the writer
+ * (the node widget answering the R/U keybind) and the reader (the NEI overlay handler) have no
+ * reference to each other and NEI constructs its handlers itself, so the shared session instance
+ * lives on the API facade.
+ *
+ * <p>
+ * Fluids are covered because NEI's lookup currency is the ItemStack: a fluid port answers R/U
+ * with its GT fluid display stack, and the overlay handler translates display stacks back to
+ * fluids when matching ports.
  */
 public final class NodeLookupContext {
 
-    @Nullable
-    private static UUID nodeId;
-    @Nullable
-    private static ItemStack stack;
+    /** The node and ingredient an NEI lookup started from. */
+    public record Origin(UUID nodeId, ItemStack stack) {}
 
-    private NodeLookupContext() {}
+    @Nullable
+    private Origin origin;
 
-    public static void set(final UUID originNodeId, final ItemStack lookupStack) {
-        nodeId = originNodeId;
-        stack = lookupStack;
+    public void set(final UUID originNodeId, final ItemStack lookupStack) {
+        origin = new Origin(originNodeId, lookupStack);
     }
 
+    /**
+     * Returns the pending origin and clears it: a lookup wires at most one added recipe, so a
+     * stale origin can never auto-connect something added much later in the session.
+     */
     @Nullable
-    public static UUID nodeId() {
-        return nodeId;
-    }
-
-    @Nullable
-    public static ItemStack stack() {
-        return stack;
+    public Origin consume() {
+        final Origin result = origin;
+        origin = null;
+        return result;
     }
 }

--- a/src/main/java/com/sbancuz/plannh/nei/PlanOverlayHandler.java
+++ b/src/main/java/com/sbancuz/plannh/nei/PlanOverlayHandler.java
@@ -2,21 +2,28 @@ package com.sbancuz.plannh.nei;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
 
+import com.cleanroommc.modularui.ModularUI;
 import com.cleanroommc.modularui.screen.GuiContainerWrapper;
 import com.sbancuz.plannh.api.PlanAPI;
 import com.sbancuz.plannh.api.RecipePropertyAPI;
 import com.sbancuz.plannh.data.PropertyProvider;
+import com.sbancuz.plannh.data.flowchart.Edge;
 import com.sbancuz.plannh.data.flowchart.Graph;
 import com.sbancuz.plannh.data.flowchart.Node;
+import com.sbancuz.plannh.data.flowchart.Port;
 import com.sbancuz.plannh.gui.FlowchartScreen;
 
 import codechicken.nei.PositionedStack;
 import codechicken.nei.api.IOverlayHandler;
 import codechicken.nei.recipe.GuiOverlayButton;
 import codechicken.nei.recipe.IRecipeHandler;
+import gregtech.api.util.GTUtility;
 
 public class PlanOverlayHandler implements IOverlayHandler {
 
@@ -55,12 +62,73 @@ public class PlanOverlayHandler implements IOverlayHandler {
         final Node node = new Node(handler, recipeIndex, DEFAULT_NODE_X, DEFAULT_NODE_Y);
         final Graph graph = PlanAPI.getActiveGraph();
         graph.addNode(node);
+        autoConnectToLookupOrigin(graph, node);
         PlanAPI.save();
 
         if (firstGui instanceof final GuiContainerWrapper wrapper
             && wrapper.getScreen() instanceof final FlowchartScreen screen) {
             screen.canvas.rebuildNodeWidgets();
         }
+    }
+
+    /**
+     * If this recipe was added from an NEI lookup started on a node's ingredient (R/U on a
+     * PlanNH node), wire the new node to that origin - but only on the looked-up ingredient, so
+     * lookups that wandered several recipe layers deep don't create bogus edges.
+     */
+    private static void autoConnectToLookupOrigin(final Graph graph, final Node added) {
+        final UUID originId = NodeLookupContext.nodeId();
+        final ItemStack lookup = NodeLookupContext.stack();
+        if (originId == null || lookup == null) return;
+        final Node origin = graph.nodes.get(originId);
+        if (origin == null || origin.id.equals(added.id)) return;
+
+        // R lookup: the new recipe produces what the origin consumes...
+        if (connectOnIngredient(graph, added, origin, lookup)) return;
+        // ...or U lookup: the new recipe consumes what the origin produces.
+        connectOnIngredient(graph, origin, added, lookup);
+    }
+
+    /** Wires src's lookup-matching output to dst's first compatible (preferably unfed) input. */
+    private static boolean connectOnIngredient(final Graph graph, final Node src, final Node dst,
+        final ItemStack lookup) {
+        for (int out = 0; out < src.outputs.size(); out++) {
+            final Port<?> outPort = src.outputs.get(out);
+            if (!portMatchesLookup(outPort, lookup)) continue;
+            int chosen = -1;
+            for (int in = 0; in < dst.inputs.size(); in++) {
+                if (!outPort.canConnect(dst.inputs.get(in))) continue;
+                if (chosen < 0) chosen = in;
+                if (!hasIncomingEdge(graph, dst.id, in)) {
+                    chosen = in;
+                    break;
+                }
+            }
+            if (chosen >= 0) {
+                graph.addEdge(new Edge(UUID.randomUUID(), src.id, dst.id, out, chosen));
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean portMatchesLookup(final Port<?> port, final ItemStack lookup) {
+        final Object value = port.getValue();
+        if (value instanceof final ItemStack stack) {
+            return stack.isItemEqual(lookup);
+        }
+        if (value instanceof final FluidStack fluidValue && ModularUI.Mods.GT5U.isLoaded()) {
+            final FluidStack lookupFluid = GTUtility.getFluidFromDisplayStack(lookup);
+            return lookupFluid != null && lookupFluid.getFluid() == fluidValue.getFluid();
+        }
+        return false;
+    }
+
+    private static boolean hasIncomingEdge(final Graph graph, final UUID nodeId, final int inputIndex) {
+        for (final Edge edge : graph.getEdges()) {
+            if (edge.targetNodeId.equals(nodeId) && edge.targetInputIndex == inputIndex) return true;
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/com/sbancuz/plannh/nei/PlanOverlayHandler.java
+++ b/src/main/java/com/sbancuz/plannh/nei/PlanOverlayHandler.java
@@ -78,15 +78,9 @@ public class PlanOverlayHandler implements IOverlayHandler {
     }
 
     /**
-     * If this recipe was added from an NEI lookup started on a node's port (R/U on a PlanNH
-     * node), wire the new node to that exact port. Direction follows the port's side: an input
-     * port wanted a producer (what R lookups list), an output port wanted a consumer (U
-     * lookups). An unrelated recipe reached by wandering NEI layers deep has no port that
-     * {@code canConnect}s the origin port, so it wires nothing.
-     *
-     * <p>
-     * A wired node is also placed beside its origin (producers left, consumers right) instead of
-     * at the default spawn position.
+     * If this recipe was added from an NEI lookup started on a node's port, wire the new node
+     * to that exact port and place it beside the origin node. Direction follows the port's side: an
+     * inputs on the left, outputs on the right.
      */
     private static void autoConnectToLookupOrigin(final Graph graph, final Node added,
         @Nullable final NodeLookupContext lookupOrigin, final CanvasWidget canvas) {

--- a/src/main/java/com/sbancuz/plannh/nei/PlanOverlayHandler.java
+++ b/src/main/java/com/sbancuz/plannh/nei/PlanOverlayHandler.java
@@ -4,29 +4,24 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiScreen;
+import javax.annotation.Nullable;
+
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.fluids.FluidStack;
 
 import com.cleanroommc.modularui.screen.GuiContainerWrapper;
-import com.sbancuz.plannh.Compat;
 import com.sbancuz.plannh.api.PlanAPI;
 import com.sbancuz.plannh.api.RecipePropertyAPI;
 import com.sbancuz.plannh.data.PropertyProvider;
 import com.sbancuz.plannh.data.flowchart.Edge;
 import com.sbancuz.plannh.data.flowchart.Graph;
 import com.sbancuz.plannh.data.flowchart.Node;
-import com.sbancuz.plannh.data.flowchart.Port;
-import com.sbancuz.plannh.data.provider.gregtech.GTHooks;
+import com.sbancuz.plannh.gui.CanvasWidget;
 import com.sbancuz.plannh.gui.FlowchartScreen;
 
 import codechicken.nei.PositionedStack;
 import codechicken.nei.api.IOverlayHandler;
-import codechicken.nei.recipe.GuiCraftingRecipe;
 import codechicken.nei.recipe.GuiOverlayButton;
-import codechicken.nei.recipe.GuiUsageRecipe;
 import codechicken.nei.recipe.IRecipeHandler;
 
 public class PlanOverlayHandler implements IOverlayHandler {
@@ -66,11 +61,18 @@ public class PlanOverlayHandler implements IOverlayHandler {
         final Node node = new Node(handler, recipeIndex, DEFAULT_NODE_X, DEFAULT_NODE_Y);
         final Graph graph = PlanAPI.getActiveGraph();
         graph.addNode(node);
-        autoConnectToLookupOrigin(graph, node);
-        PlanAPI.save();
 
-        if (firstGui instanceof final GuiContainerWrapper wrapper
-            && wrapper.getScreen() instanceof final FlowchartScreen screen) {
+        final FlowchartScreen screen = firstGui instanceof final GuiContainerWrapper wrapper
+            && wrapper.getScreen() instanceof final FlowchartScreen s ? s : null;
+        if (screen != null) {
+            autoConnectToLookupOrigin(
+                graph,
+                node,
+                screen.canvas.consumePendingLookup(),
+                screen.canvas);
+        }
+        PlanAPI.save();
+        if (screen != null) {
             screen.canvas.rebuildNodeWidgets();
         }
     }
@@ -81,25 +83,27 @@ public class PlanOverlayHandler implements IOverlayHandler {
      * lookups that wandered several recipe layers deep don't create bogus edges.
      *
      * <p>
-     * The lookup DIRECTION comes from the NEI screen the + was clicked on: a recipe screen
-     * (GuiCraftingRecipe, the R key) lists producers of the ingredient, so the added node feeds
-     * the origin; a usage screen (GuiUsageRecipe, the U key) lists consumers, so the origin
-     * feeds the added node. MUI2's ingredient provider cannot distinguish R from U at lookup
-     * time, which is why the flag is read here rather than stored in the context.
+     * The lookup DIRECTION follows which side of the added recipe carries the ingredient: a
+     * producer (what R lookups list) feeds the origin, a consumer (U lookups) is fed by it. The
+     * NEI screen type cannot decide this - GuiOverlayButton switches back to the flowchart
+     * before invoking the overlay handler, so the recipe screen is already gone here - and after
+     * wandering several layers deep it would not reflect the original R/U anyway.
+     *
+     * <p>
+     * A wired node is also placed beside its origin (producers left, consumers right) instead of
+     * at the default spawn position.
      */
-    private static void autoConnectToLookupOrigin(final Graph graph, final Node added) {
-        final NodeLookupContext.Origin lookupOrigin = PlanAPI.lookupContext()
-            .consume();
+    private static void autoConnectToLookupOrigin(final Graph graph, final Node added,
+        @Nullable final NodeLookupContext lookupOrigin, final CanvasWidget canvas) {
         if (lookupOrigin == null) return;
         final Node origin = graph.nodes.get(lookupOrigin.nodeId());
         final ItemStack lookup = lookupOrigin.stack();
         if (origin == null || lookup == null || origin.id.equals(added.id)) return;
 
-        final GuiScreen current = Minecraft.getMinecraft().currentScreen;
-        if (current instanceof GuiUsageRecipe) {
-            connectOnIngredient(graph, origin, added, lookup);
-        } else if (current instanceof GuiCraftingRecipe) {
-            connectOnIngredient(graph, added, origin, lookup);
+        if (connectOnIngredient(graph, added, origin, lookup)) {
+            canvas.placeBesideOrigin(added, origin, true);
+        } else if (connectOnIngredient(graph, origin, added, lookup)) {
+            canvas.placeBesideOrigin(added, origin, false);
         }
     }
 
@@ -107,40 +111,13 @@ public class PlanOverlayHandler implements IOverlayHandler {
     private static boolean connectOnIngredient(final Graph graph, final Node src, final Node dst,
         final ItemStack lookup) {
         for (int out = 0; out < src.outputs.size(); out++) {
-            final Port<?> outPort = src.outputs.get(out);
-            if (!portMatchesLookup(outPort, lookup)) continue;
-            int chosen = -1;
-            for (int in = 0; in < dst.inputs.size(); in++) {
-                if (!outPort.canConnect(dst.inputs.get(in))) continue;
-                if (chosen < 0) chosen = in;
-                if (!hasIncomingEdge(graph, dst.id, in)) {
-                    chosen = in;
-                    break;
-                }
-            }
-            if (chosen >= 0) {
-                graph.addEdge(new Edge(UUID.randomUUID(), src.id, dst.id, out, chosen));
+            if (!src.outputs.get(out)
+                .matchesLookup(lookup)) continue;
+            final int in = graph.findCompatibleInput(src, out, dst);
+            if (in >= 0) {
+                graph.addEdge(new Edge(UUID.randomUUID(), src.id, dst.id, out, in));
                 return true;
             }
-        }
-        return false;
-    }
-
-    private static boolean portMatchesLookup(final Port<?> port, final ItemStack lookup) {
-        final Object value = port.getValue();
-        if (value instanceof final ItemStack stack) {
-            return stack.isItemEqual(lookup);
-        }
-        if (value instanceof final FluidStack fluidValue && Compat.GREGTECH.isLoaded) {
-            final FluidStack lookupFluid = GTHooks.fluidFromDisplayStack(lookup);
-            return lookupFluid != null && lookupFluid.getFluid() == fluidValue.getFluid();
-        }
-        return false;
-    }
-
-    private static boolean hasIncomingEdge(final Graph graph, final UUID nodeId, final int inputIndex) {
-        for (final Edge edge : graph.getEdges()) {
-            if (edge.targetNodeId.equals(nodeId) && edge.targetInputIndex == inputIndex) return true;
         }
         return false;
     }

--- a/src/main/java/com/sbancuz/plannh/nei/PlanOverlayHandler.java
+++ b/src/main/java/com/sbancuz/plannh/nei/PlanOverlayHandler.java
@@ -4,12 +4,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
-import com.cleanroommc.modularui.ModularUI;
 import com.cleanroommc.modularui.screen.GuiContainerWrapper;
+import com.sbancuz.plannh.Compat;
 import com.sbancuz.plannh.api.PlanAPI;
 import com.sbancuz.plannh.api.RecipePropertyAPI;
 import com.sbancuz.plannh.data.PropertyProvider;
@@ -17,13 +19,15 @@ import com.sbancuz.plannh.data.flowchart.Edge;
 import com.sbancuz.plannh.data.flowchart.Graph;
 import com.sbancuz.plannh.data.flowchart.Node;
 import com.sbancuz.plannh.data.flowchart.Port;
+import com.sbancuz.plannh.data.provider.gregtech.GTHooks;
 import com.sbancuz.plannh.gui.FlowchartScreen;
 
 import codechicken.nei.PositionedStack;
 import codechicken.nei.api.IOverlayHandler;
+import codechicken.nei.recipe.GuiCraftingRecipe;
 import codechicken.nei.recipe.GuiOverlayButton;
+import codechicken.nei.recipe.GuiUsageRecipe;
 import codechicken.nei.recipe.IRecipeHandler;
-import gregtech.api.util.GTUtility;
 
 public class PlanOverlayHandler implements IOverlayHandler {
 
@@ -75,18 +79,28 @@ public class PlanOverlayHandler implements IOverlayHandler {
      * If this recipe was added from an NEI lookup started on a node's ingredient (R/U on a
      * PlanNH node), wire the new node to that origin - but only on the looked-up ingredient, so
      * lookups that wandered several recipe layers deep don't create bogus edges.
+     *
+     * <p>
+     * The lookup DIRECTION comes from the NEI screen the + was clicked on: a recipe screen
+     * (GuiCraftingRecipe, the R key) lists producers of the ingredient, so the added node feeds
+     * the origin; a usage screen (GuiUsageRecipe, the U key) lists consumers, so the origin
+     * feeds the added node. MUI2's ingredient provider cannot distinguish R from U at lookup
+     * time, which is why the flag is read here rather than stored in the context.
      */
     private static void autoConnectToLookupOrigin(final Graph graph, final Node added) {
-        final UUID originId = NodeLookupContext.nodeId();
-        final ItemStack lookup = NodeLookupContext.stack();
-        if (originId == null || lookup == null) return;
-        final Node origin = graph.nodes.get(originId);
-        if (origin == null || origin.id.equals(added.id)) return;
+        final NodeLookupContext.Origin lookupOrigin = PlanAPI.lookupContext()
+            .consume();
+        if (lookupOrigin == null) return;
+        final Node origin = graph.nodes.get(lookupOrigin.nodeId());
+        final ItemStack lookup = lookupOrigin.stack();
+        if (origin == null || lookup == null || origin.id.equals(added.id)) return;
 
-        // R lookup: the new recipe produces what the origin consumes...
-        if (connectOnIngredient(graph, added, origin, lookup)) return;
-        // ...or U lookup: the new recipe consumes what the origin produces.
-        connectOnIngredient(graph, origin, added, lookup);
+        final GuiScreen current = Minecraft.getMinecraft().currentScreen;
+        if (current instanceof GuiUsageRecipe) {
+            connectOnIngredient(graph, origin, added, lookup);
+        } else if (current instanceof GuiCraftingRecipe) {
+            connectOnIngredient(graph, added, origin, lookup);
+        }
     }
 
     /** Wires src's lookup-matching output to dst's first compatible (preferably unfed) input. */
@@ -117,8 +131,8 @@ public class PlanOverlayHandler implements IOverlayHandler {
         if (value instanceof final ItemStack stack) {
             return stack.isItemEqual(lookup);
         }
-        if (value instanceof final FluidStack fluidValue && ModularUI.Mods.GT5U.isLoaded()) {
-            final FluidStack lookupFluid = GTUtility.getFluidFromDisplayStack(lookup);
+        if (value instanceof final FluidStack fluidValue && Compat.GREGTECH.isLoaded) {
+            final FluidStack lookupFluid = GTHooks.fluidFromDisplayStack(lookup);
             return lookupFluid != null && lookupFluid.getFluid() == fluidValue.getFluid();
         }
         return false;

--- a/src/main/java/com/sbancuz/plannh/nei/PlanOverlayHandler.java
+++ b/src/main/java/com/sbancuz/plannh/nei/PlanOverlayHandler.java
@@ -107,7 +107,7 @@ public class PlanOverlayHandler implements IOverlayHandler {
         }
     }
 
-    /** Wires src's lookup-matching output to dst's first compatible (preferably unfed) input. */
+    /** Wires src's lookup-matching output to dst's first compatible input. */
     private static boolean connectOnIngredient(final Graph graph, final Node src, final Node dst,
         final ItemStack lookup) {
         for (int out = 0; out < src.outputs.size(); out++) {

--- a/src/main/java/com/sbancuz/plannh/nei/PlanOverlayHandler.java
+++ b/src/main/java/com/sbancuz/plannh/nei/PlanOverlayHandler.java
@@ -7,7 +7,6 @@ import java.util.UUID;
 import javax.annotation.Nullable;
 
 import net.minecraft.client.gui.inventory.GuiContainer;
-import net.minecraft.item.ItemStack;
 
 import com.cleanroommc.modularui.screen.GuiContainerWrapper;
 import com.sbancuz.plannh.api.PlanAPI;
@@ -16,6 +15,7 @@ import com.sbancuz.plannh.data.PropertyProvider;
 import com.sbancuz.plannh.data.flowchart.Edge;
 import com.sbancuz.plannh.data.flowchart.Graph;
 import com.sbancuz.plannh.data.flowchart.Node;
+import com.sbancuz.plannh.data.flowchart.Port;
 import com.sbancuz.plannh.gui.CanvasWidget;
 import com.sbancuz.plannh.gui.FlowchartScreen;
 
@@ -78,16 +78,11 @@ public class PlanOverlayHandler implements IOverlayHandler {
     }
 
     /**
-     * If this recipe was added from an NEI lookup started on a node's ingredient (R/U on a
-     * PlanNH node), wire the new node to that origin - but only on the looked-up ingredient, so
-     * lookups that wandered several recipe layers deep don't create bogus edges.
-     *
-     * <p>
-     * The lookup DIRECTION follows which side of the added recipe carries the ingredient: a
-     * producer (what R lookups list) feeds the origin, a consumer (U lookups) is fed by it. The
-     * NEI screen type cannot decide this - GuiOverlayButton switches back to the flowchart
-     * before invoking the overlay handler, so the recipe screen is already gone here - and after
-     * wandering several layers deep it would not reflect the original R/U anyway.
+     * If this recipe was added from an NEI lookup started on a node's port (R/U on a PlanNH
+     * node), wire the new node to that exact port. Direction follows the port's side: an input
+     * port wanted a producer (what R lookups list), an output port wanted a consumer (U
+     * lookups). An unrelated recipe reached by wandering NEI layers deep has no port that
+     * {@code canConnect}s the origin port, so it wires nothing.
      *
      * <p>
      * A wired node is also placed beside its origin (producers left, consumers right) instead of
@@ -97,29 +92,27 @@ public class PlanOverlayHandler implements IOverlayHandler {
         @Nullable final NodeLookupContext lookupOrigin, final CanvasWidget canvas) {
         if (lookupOrigin == null) return;
         final Node origin = graph.nodes.get(lookupOrigin.nodeId());
-        final ItemStack lookup = lookupOrigin.stack();
-        if (origin == null || lookup == null || origin.id.equals(added.id)) return;
+        if (origin == null || origin.id.equals(added.id)) return;
+        final List<Port<?>> originPorts = lookupOrigin.output() ? origin.outputs : origin.inputs;
+        final int originIdx = lookupOrigin.portIndex();
+        if (originIdx < 0 || originIdx >= originPorts.size()) return;
 
-        if (connectOnIngredient(graph, added, origin, lookup)) {
-            canvas.placeBesideOrigin(added, origin, true);
-        } else if (connectOnIngredient(graph, origin, added, lookup)) {
-            canvas.placeBesideOrigin(added, origin, false);
-        }
-    }
-
-    /** Wires src's lookup-matching output to dst's first compatible input. */
-    private static boolean connectOnIngredient(final Graph graph, final Node src, final Node dst,
-        final ItemStack lookup) {
-        for (int out = 0; out < src.outputs.size(); out++) {
-            if (!src.outputs.get(out)
-                .matchesLookup(lookup)) continue;
-            final int in = graph.findCompatibleInput(src, out, dst);
+        if (lookupOrigin.output()) {
+            final int in = graph.findCompatibleInput(origin, originIdx, added);
             if (in >= 0) {
-                graph.addEdge(new Edge(UUID.randomUUID(), src.id, dst.id, out, in));
-                return true;
+                graph.addEdge(new Edge(UUID.randomUUID(), origin.id, added.id, originIdx, in));
+                canvas.placeBesideOrigin(added, origin, false);
+            }
+        } else {
+            final Port<?> originPort = originPorts.get(originIdx);
+            for (int out = 0; out < added.outputs.size(); out++) {
+                if (!added.outputs.get(out)
+                    .canConnect(originPort)) continue;
+                graph.addEdge(new Edge(UUID.randomUUID(), added.id, origin.id, out, originIdx));
+                canvas.placeBesideOrigin(added, origin, true);
+                break;
             }
         }
-        return false;
     }
 
     @Override


### PR DESCRIPTION
NOTE: this PR targets `balancer` branch as this is what I based the changes on; the `master` branch doesn't have functioning node rendering.

NOTE: This PR message is human made (I won't subject you to AI PR summaries), but the code in this PR is 100% AI generated. I did closely supervise it and had specific targets and test parameters for it to hit, but I can't fully attest to the actual Java code quality or existence of unwanted side effects. I am a professional Python dev, I know very little about Java. If it's any consolation, I did use Fable 5 for this, so perhaps it is good enough.

## Flowchart UI/UX

- Support R/U NEI keybinds when hovering ingredients in the flowchart
- When adding a recipe after using R/U from an ingredient in the flowchart, auto connect said recipe if it shares ingredients. This saves having to manually connect most of the time.
- When dragging an edge from a port manually, if the ingredient is a valid match to the currently hovered machine node, the ingredient snaps to the correct input without having to aim. Until mouse release, this is shown as a ghost selection (so the user can do something else if they want). In the image below, I am hovering the Gregtech logo.
<img width="657" height="278" alt="image" src="https://github.com/user-attachments/assets/4dabbc75-c8cf-43fd-9f63-743aeffe0122" />

- Make node ports and edges inherit color from the ingredient. Since NEI is the "source of truth" for what the end user thinks the ingredient looks like, render the ingredient in an off-screen framebuffer and use that for the sprite ground truth. To select the color from the sprite, the colors are cast to a 32x32x32 RGB cube and the modal color is selected. To avoid the sprite outline or transparency affecting the selected color, transparency is dropped and the edges are eroded by 4 pixels. Technical summary from Fable:
```
- **Derivation = render sampling:** the stack is rendered into a small
  offscreen framebuffer via NEI's own item drawing (the exact pipeline
  recipe screens use) and the modal color of the pixels is taken. This is
  immune to the icon API misrepresenting custom renderers (GT material
  items report white; GT blocks report unrelated casing textures; fluid
  display icons don't resolve to files). Details that mattered:
  - raw GL30 FBO with a *verified* binding — Minecraft's `Framebuffer`
    wrapper can silently no-op under Angelica, which made early versions
    sample the screen corner;
  - `GL_TEXTURE_2D` re-enabled before drawing (the sampler runs mid-GUI
    draw after untextured rect drawing);
  - the amount-text overlay suppressed (its white pixels won the vote);
  - sprite outlines eroded (pixels adjacent to transparency) and the
    histogram saturation-weighted, so pale gradient sprites (diamond)
    resolve to their hue instead of their white shine;
  - fallback chain for environments without GL30/rendering: per-pass
    sprite reads (GT material tint applied), resource-pack PNGs (Angelica
    frees the atlas' CPU-side frame data), fluid display stacks, and the
    old type colors as last resort.
- **Colors stay true to the sprite** (no luminance lift): readability on
  arbitrary world backgrounds comes from **contrast-adaptive outlines** —
  light outline under dark colors, dark under light — on both edges and
  pins, plus a wider dark underlay beneath edge lines and arrowheads.
```
<img width="1675" height="992" alt="image" src="https://github.com/user-attachments/assets/0400859e-aa1d-49d3-b990-1784d0e67806" />

- Set machine node titles to black for better contrast
<img width="389" height="205" alt="image" src="https://github.com/user-attachments/assets/c3323f31-e8f9-4586-9c1a-2f04b53211d9" />

- Fix flowchart zoom (not sure if you guys where having this issue, but the zoom on mine was slamming between 10% and 500%). Fable said this might be due to a MUI bug on dev installations:
```
- MUI2 passes the raw LWJGL wheel delta; real LWJGL2 reports
  ±120 per notch while lwjgl3ify (all modern GTNH packs) reports notch
  counts. Amounts ≥120 are now normalized by the LWJGL2 convention; pack
  behavior is byte-identical to before.
```
- Remove the port node label in favor of the usual NEI hover label. This may be a controversial change, so I can revert it if you like. My reasoning on this was that the old port label was having Z-fighting issues, sometimes it would render behind other nodes as it was part of the node rendering layer. From a UX perspective, the end user should never have to redesign their flowchart layout because they can't read a hover tooltip. This also frees up some space later to add edge quantities, which is in your TODO list.
<img width="601" height="304" alt="image" src="https://github.com/user-attachments/assets/ab707255-9bb9-487c-9124-e8ba00614357" />

- New nodes from NEI are now auto-placed rather than stacked on the (200, 200) origin. If the ingredient is an input, it goes on the left, if it's an output, it goes on the right. Auto-placed machine nodes are slightly offset to avoid edge collisions, and nodes are placed lower if there are existing nodes in the way

## Developer QOL

- Enforce single edge between port pairs
- Add -PgtnhRecipes flag to `./gradlew runClient` - this makes evaluating the balancer much easier
- Right now the derived colors are logged to `logs/fml-client-latest.log` for development purposes - this should be removed before 1.0 reease