### PR TITLE
Add auto-layout button

### DIFF
--- a/addon.gradle
+++ b/addon.gradle
@@ -1,0 +1,16 @@
+// Applied by gtnhgradle's AddonScriptModule alongside the standard convention scripts.
+
+// The shaded ELK distribution ships its documentation-site illustrations (images/**) and
+// EMF design-time metamodels (model/**); both are dead weight at runtime.
+tasks.matching { it.name == 'shadowJar' }.configureEach {
+    exclude 'images/**'
+    exclude 'model/**'
+}
+
+// ELK declares guava as the open range [15.0,), which re-resolves to the newest guava on
+// every fresh resolution - unreproducible builds and a needlessly fat shaded jar. Pin the
+// ELK-0.8-era release. Scoped to the shadow configurations so the dev/runtime classpath
+// (which must keep Minecraft's guava) is untouched.
+configurations.matching { it.name.toLowerCase(Locale.ROOT).contains('shadow') }.configureEach {
+    resolutionStrategy.force('com.google.guava:guava:30.1-jre')
+}

--- a/addon.gradle
+++ b/addon.gradle
@@ -1,10 +1,20 @@
 // Applied by gtnhgradle's AddonScriptModule alongside the standard convention scripts.
 
-// The shaded ELK distribution ships its documentation-site illustrations (images/**) and
-// EMF design-time metamodels (model/**); both are dead weight at runtime.
+// The shaded ELK distribution ships its documentation-site illustrations (images/**), EMF
+// design-time metamodels (model/** and schema/**), Eclipse plugin descriptors, and docs;
+// all dead weight at runtime, and the descriptors would sit at the jar's top level.
 tasks.matching { it.name == 'shadowJar' }.configureEach {
     exclude 'images/**'
     exclude 'model/**'
+    exclude 'schema/**'
+    exclude 'docs/**'
+    exclude 'about.*'
+    exclude 'plugin.xml'
+    exclude 'plugin.properties'
+    exclude 'modeling32.png'
+    exclude 'META-INF/maven/**'
+    exclude 'META-INF/LICENSE*'
+    exclude 'META-INF/NOTICE*'
 }
 
 // ELK declares guava as the open range [15.0,), which re-resolves to the newest guava on

--- a/addon.gradle
+++ b/addon.gradle
@@ -4,6 +4,11 @@
 // design-time metamodels (model/** and schema/**), Eclipse plugin descriptors, and docs;
 // all dead weight at runtime, and the descriptors would sit at the jar's top level.
 tasks.matching { it.name == 'shadowJar' }.configureEach {
+    // Three ELK jars each declare an ILayoutMetaDataProvider service. Without this, shadow keeps
+    // one of the three and leaves its filename and contents on the original package names, so a
+    // ServiceLoader in the relocated ELK finds nothing - in the shipped jar only, never in dev.
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    mergeServiceFiles()
     exclude 'images/**'
     exclude 'model/**'
     exclude 'schema/**'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -64,4 +64,7 @@ dependencies {
     if (project.hasProperty('gtnhRecipes')) {
         runtimeOnlyNonPublishable('com.github.GTNewHorizons:NewHorizonsCoreMod:2.9.13:dev')
     }
+
+    // Auto-layout engine. 0.8.x is the last Java 8 compatible ELK release line.
+    shadowImplementation('org.eclipse.elk:org.eclipse.elk.alg.layered:0.8.1')
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -66,5 +66,8 @@ dependencies {
     }
 
     // Auto-layout engine. 0.8.x is the last Java 8 compatible ELK release line.
-    shadowImplementation('org.eclipse.elk:org.eclipse.elk.alg.layered:0.8.1')
+    shadowImplementation('org.eclipse.elk:org.eclipse.elk.alg.layered:0.8.1') {
+        // XMI is EMF's file serialization; PlanNH only builds ELK graphs programmatically.
+        exclude group: 'org.eclipse.emf', module: 'org.eclipse.emf.ecore.xmi'
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -130,11 +130,12 @@ forceEnableMixins = false
 
 # If enabled, you may use 'shadowCompile' for dependencies. They will be integrated into your jar. It is your
 # responsibility to check the license and request permission for distribution if required.
-usesShadowedDependencies = false
+usesShadowedDependencies = true
 
 # If disabled, won't remove unused classes from shadowed dependencies. Some libraries use reflection to access
 # their own classes, making the minimization unreliable.
-minimizeShadowedDependencies = true
+# Disabled: ELK's graph model is EMF-based and EMF resolves its own classes reflectively.
+minimizeShadowedDependencies = false
 
 # If disabled, won't rename the shadowed classes.
 relocateShadowedDependencies = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -138,7 +138,7 @@ usesShadowedDependencies = true
 minimizeShadowedDependencies = false
 
 # If disabled, won't rename the shadowed classes.
-relocateShadowedDependencies = true
+relocateShadowedDependencies = false
 
 # Adds CurseMaven, Modrinth, and some more well-known 1.7.10 repositories.
 includeWellKnownRepositories = true

--- a/src/main/java/com/sbancuz/plannh/ClientProxy.java
+++ b/src/main/java/com/sbancuz/plannh/ClientProxy.java
@@ -13,6 +13,7 @@ import com.sbancuz.plannh.client.ChatHandler;
 import com.sbancuz.plannh.client.ImportCommand;
 import com.sbancuz.plannh.client.WorldHandler;
 import com.sbancuz.plannh.gui.FlowchartScreen;
+import com.sbancuz.plannh.layout.AutoLayout;
 
 import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.common.FMLCommonHandler;
@@ -54,6 +55,13 @@ public class ClientProxy extends CommonProxy {
         FMLCommonHandler.instance()
             .bus()
             .register(this);
+
+        // ELK's first layout pays for its class loading and metadata registration; warm it up
+        // off-thread so the first Auto-Layout click doesn't freeze the game.
+        final Thread elkWarmup = new Thread(AutoLayout::warmup, "PlanNH ELK warmup");
+        elkWarmup.setDaemon(true);
+        elkWarmup.setPriority(Thread.MIN_PRIORITY);
+        elkWarmup.start();
     }
 
     @SubscribeEvent

--- a/src/main/java/com/sbancuz/plannh/ClientProxy.java
+++ b/src/main/java/com/sbancuz/plannh/ClientProxy.java
@@ -56,12 +56,9 @@ public class ClientProxy extends CommonProxy {
             .bus()
             .register(this);
 
-        // ELK's first layout pays for its class loading and metadata registration; warm it up
-        // off-thread so the first Auto-Layout click doesn't freeze the game.
-        final Thread elkWarmup = new Thread(AutoLayout::warmup, "PlanNH ELK warmup");
-        elkWarmup.setDaemon(true);
-        elkWarmup.setPriority(Thread.MIN_PRIORITY);
-        elkWarmup.start();
+        // ELK's first layout pays for its class loading and metadata registration; spend it
+        // during init so the first Auto-Layout click doesn't freeze the game.
+        AutoLayout.warmup();
     }
 
     @SubscribeEvent

--- a/src/main/java/com/sbancuz/plannh/ClientProxy.java
+++ b/src/main/java/com/sbancuz/plannh/ClientProxy.java
@@ -56,15 +56,7 @@ public class ClientProxy extends CommonProxy {
             .bus()
             .register(this);
 
-        // ELK's first layout pays for its class loading and metadata registration; spend it
-        // during init so the first Auto-Layout click doesn't freeze the game. AutoLayout's static
-        // block runs on this call, so a mis-shaded ELK fails here as a LinkageError - which must
-        // cost the mod its layout button, not its startup.
-        try {
-            AutoLayout.warmup();
-        } catch (final RuntimeException | LinkageError e) {
-            PlanNH.LOG.error("ELK warm-up failed; Auto-Layout will be unavailable", e);
-        }
+        Minecraft.getMinecraft().func_152344_a(AutoLayout::warmup);
     }
 
     @SubscribeEvent

--- a/src/main/java/com/sbancuz/plannh/ClientProxy.java
+++ b/src/main/java/com/sbancuz/plannh/ClientProxy.java
@@ -57,8 +57,14 @@ public class ClientProxy extends CommonProxy {
             .register(this);
 
         // ELK's first layout pays for its class loading and metadata registration; spend it
-        // during init so the first Auto-Layout click doesn't freeze the game.
-        AutoLayout.warmup();
+        // during init so the first Auto-Layout click doesn't freeze the game. AutoLayout's static
+        // block runs on this call, so a mis-shaded ELK fails here as a LinkageError - which must
+        // cost the mod its layout button, not its startup.
+        try {
+            AutoLayout.warmup();
+        } catch (final RuntimeException | LinkageError e) {
+            PlanNH.LOG.error("ELK warm-up failed; Auto-Layout will be unavailable", e);
+        }
     }
 
     @SubscribeEvent

--- a/src/main/java/com/sbancuz/plannh/ClientProxy.java
+++ b/src/main/java/com/sbancuz/plannh/ClientProxy.java
@@ -56,7 +56,8 @@ public class ClientProxy extends CommonProxy {
             .bus()
             .register(this);
 
-        Minecraft.getMinecraft().func_152344_a(AutoLayout::warmup);
+        Minecraft.getMinecraft()
+            .func_152344_a(AutoLayout::warmup);
     }
 
     @SubscribeEvent

--- a/src/main/java/com/sbancuz/plannh/Config.java
+++ b/src/main/java/com/sbancuz/plannh/Config.java
@@ -6,8 +6,17 @@ import net.minecraftforge.common.config.Configuration;
 
 public final class Config {
 
+    /** Dev diagnostic: log a headless repro of every arrow-routing recompute. */
+    public static boolean debugRouteDump = false;
+
     public static void synchronizeConfiguration(final File configFile) {
         final Configuration configuration = new Configuration(configFile);
+
+        debugRouteDump = configuration.getBoolean(
+            "debugRouteDump",
+            "debug",
+            false,
+            "Log a replayable dump of the arrow-routing input on every route recompute");
 
         if (configuration.hasChanged()) {
             configuration.save();

--- a/src/main/java/com/sbancuz/plannh/gui/ArrowRouter.java
+++ b/src/main/java/com/sbancuz/plannh/gui/ArrowRouter.java
@@ -18,20 +18,41 @@ import java.util.UUID;
  * produced paths stable while the user pans (a pure translation) and lets the caller cache them.
  * <p>
  * The router lays a uniform grid over the bounding region and runs A* where the search state is
- * {@code (cell, incoming-direction)} so that turns can be penalized. Node rectangles inflated by a
- * margin are hard obstacles; cells already occupied by a routed arrow carry a soft penalty so that
- * later arrows take a parallel track instead of overlapping.
+ * {@code (cell, incoming-direction)} so that turns can be penalized. Node rectangles are hard
+ * obstacles; their surrounding margin ring and cells already occupied by a routed arrow carry soft
+ * penalties, so arrows keep clearance where there is room but can squeeze through tight gaps.
  */
 public final class ArrowRouter {
 
     /** Per-cell movement cost. */
     private static final int STEP = 1;
-    /** Extra cost for changing direction. Keeps the number of bends low. */
-    private static final int TURN = 12;
-    /** Extra cost per cell that already carries another arrow. Makes arrows separate. */
-    private static final int ARROW = 4;
+    /**
+     * Extra cost for changing direction. High relative to STEP so paths never micro-dodge
+     * around mild congestion - a single sideways jog costs two turns, which no small
+     * occupancy saving can justify.
+     */
+    private static final int TURN = 24;
+    /**
+     * Extra cost per cell that already carries another arrow. Kept low relative to STEP so
+     * that sharing even a long congested corridor stays cheaper than detouring around the
+     * outside of the chart.
+     */
+    private static final int ARROW = 2;
     /** Smaller penalty around an occupied cell, so arrows keep at least one cell of clearance. */
     private static final int NEAR = 1;
+    /**
+     * Penalty per cell inside a node's margin ring. The ring is deliberately soft, not blocked:
+     * nodes placed with a gap smaller than two margins would otherwise seal the gap shut and
+     * force absurd whole-chart detours. Arrows avoid hugging nodes when there is room, but can
+     * squeeze through tight gaps when there is not.
+     */
+    private static final int MARGIN_COST = 8;
+    /**
+     * Penalty for routing through another edge's port anchor (the straight approach run just
+     * right of an output pin / just left of an input pin). Anchors stay visually clear so every
+     * arrow's first and last segment reads as belonging to its port.
+     */
+    private static final int ANCHOR_COST = 30;
 
     /** Hard cap on grid cells; the cell size is grown if a region would exceed it. */
     private static final int MAX_CELLS = 200_000;
@@ -103,9 +124,17 @@ public final class ArrowRouter {
 
         final Grid grid = new Grid(minX, minY, cols, rows, cell, stub);
         grid.blockObstacles(obstacles, margin);
+        grid.reserveAnchors(requests);
 
-        for (final Request q : requests) {
-            final List<int[]> cellPath = grid.search(q);
+        for (int i = 0; i < requests.size(); i++) {
+            final Request q = requests.get(i);
+            // Ports closer than two anchor stubs cannot satisfy the leave-right/arrive-right
+            // state machine without looping around themselves; draw the canonical Z directly.
+            if (q.dx - q.sx < 2 * stub && Math.abs(q.dy - q.sy) < 10 * baseCell) {
+                result.put(q.key, fallback(q, stub));
+                continue;
+            }
+            final List<int[]> cellPath = grid.search(q, i);
             final List<int[]> path;
             if (cellPath == null) {
                 path = fallback(q, stub);
@@ -134,6 +163,7 @@ public final class ArrowRouter {
         final int originX, originY, cols, rows, cell, stub;
         final boolean[] blocked;
         final int[] occupancy;
+        final int[] anchorOwner;
         final int[] gScore;
         final int[] cameFrom;
         final int[] scoreRun;
@@ -148,6 +178,8 @@ public final class ArrowRouter {
             this.stub = stub;
             this.blocked = new boolean[cols * rows];
             this.occupancy = new int[cols * rows];
+            this.anchorOwner = new int[cols * rows];
+            Arrays.fill(anchorOwner, -1);
             final int states = cols * rows * 4;
             this.gScore = new int[states];
             this.cameFrom = new int[states];
@@ -174,11 +206,33 @@ public final class ArrowRouter {
             for (final Rect r : obstacles) {
                 final int x0 = gx(r.x - margin), x1 = gx(r.x + r.w + margin);
                 final int y0 = gy(r.y - margin), y1 = gy(r.y + r.h + margin);
+                final int bx0 = gx(r.x), bx1 = gx(r.x + r.w);
+                final int by0 = gy(r.y), by1 = gy(r.y + r.h);
                 for (int y = y0; y <= y1; y++) {
                     for (int x = x0; x <= x1; x++) {
-                        blocked[y * cols + x] = true;
+                        if (x >= bx0 && x <= bx1 && y >= by0 && y <= by1) {
+                            blocked[y * cols + x] = true;
+                        } else {
+                            occupancy[y * cols + x] += MARGIN_COST;
+                        }
                     }
                 }
+            }
+        }
+
+        /** Marks every request's port-approach runs so other arrows keep out of them. */
+        void reserveAnchors(final List<Request> requests) {
+            for (int i = 0; i < requests.size(); i++) {
+                final Request q = requests.get(i);
+                markAnchor(gx(q.sx), gx(q.sx + stub), gy(q.sy), i);
+                markAnchor(gx(q.dx - stub), gx(q.dx), gy(q.dy), i);
+            }
+        }
+
+        private void markAnchor(final int x0, final int x1, final int y, final int owner) {
+            for (int x = x0; x <= x1; x++) {
+                final int idx = y * cols + x;
+                if (anchorOwner[idx] == -1) anchorOwner[idx] = owner;
             }
         }
 
@@ -196,7 +250,7 @@ public final class ArrowRouter {
         }
 
         /** A* over (cell, direction); returns the list of {@code {gx, gy}} cells or null. */
-        List<int[]> search(final Request q) {
+        List<int[]> search(final Request q, final int requestIndex) {
             final int sgx = gx(q.sx + stub), sgy = gy(q.sy);
             final int ggx = gx(q.dx - stub), ggy = gy(q.dy);
             final int run = nextRun();
@@ -229,10 +283,11 @@ public final class ArrowRouter {
                     final int ny = cy + DY[nd];
                     if (nx < 0 || nx >= cols || ny < 0 || ny >= rows) continue;
                     final int nIdx = ny * cols + nx;
-                    final boolean isGoal = nx == ggx && ny == ggy;
-                    if (blocked[nIdx] && !isGoal) continue;
+                    if (blocked[nIdx]) continue;
 
-                    final int cost = STEP + (nd != dir ? TURN : 0) + occupancy[nIdx];
+                    final int foreignAnchor = anchorOwner[nIdx] != -1 && anchorOwner[nIdx] != requestIndex ? ANCHOR_COST
+                        : 0;
+                    final int cost = STEP + (nd != dir ? TURN : 0) + occupancy[nIdx] + foreignAnchor;
                     final int ng = g + cost;
                     final int nState = nIdx * 4 + nd;
                     if (ng < score(nState, run)) {

--- a/src/main/java/com/sbancuz/plannh/gui/ArrowRouter.java
+++ b/src/main/java/com/sbancuz/plannh/gui/ArrowRouter.java
@@ -2,6 +2,7 @@ package com.sbancuz.plannh.gui;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -26,31 +27,23 @@ public final class ArrowRouter {
 
     /** Per-cell movement cost. */
     private static final int STEP = 1;
-    /**
-     * Extra cost for changing direction. High relative to STEP so paths never micro-dodge
-     * around mild congestion - a single sideways jog costs two turns, which no small
-     * occupancy saving can justify.
-     */
+    /** Extra cost per direction change; high relative to STEP so paths don't micro-dodge. */
     private static final int TURN = 24;
     /**
-     * Extra cost per cell that already carries another arrow. Kept low relative to STEP so
-     * that sharing even a long congested corridor stays cheaper than detouring around the
-     * outside of the chart.
+     * Extra cost per cell already carrying another arrow; low, so sharing a long corridor
+     * stays cheaper than detouring around the chart.
      */
     private static final int ARROW = 2;
     /** Smaller penalty around an occupied cell, so arrows keep at least one cell of clearance. */
     private static final int NEAR = 1;
     /**
-     * Penalty per cell inside a node's margin ring. The ring is deliberately soft, not blocked:
-     * nodes placed with a gap smaller than two margins would otherwise seal the gap shut and
-     * force absurd whole-chart detours. Arrows avoid hugging nodes when there is room, but can
-     * squeeze through tight gaps when there is not.
+     * Penalty per cell in a node's margin ring. Soft rather than blocked: hard margins seal
+     * any gap narrower than two margins and force whole-chart detours.
      */
     private static final int MARGIN_COST = 8;
     /**
-     * Penalty for routing through another edge's port anchor (the straight approach run just
-     * right of an output pin / just left of an input pin). Anchors stay visually clear so every
-     * arrow's first and last segment reads as belonging to its port.
+     * Penalty for crossing another edge's port anchor (the straight approach run beside a
+     * pin), keeping each pin's first and last segment visually its own.
      */
     private static final int ANCHOR_COST = 30;
 
@@ -330,7 +323,7 @@ public final class ArrowRouter {
                 cells.add(new int[] { idx % cols, idx / cols });
                 s = cameFrom[s];
             }
-            java.util.Collections.reverse(cells);
+            Collections.reverse(cells);
             return cells;
         }
 

--- a/src/main/java/com/sbancuz/plannh/gui/ArrowRouter.java
+++ b/src/main/java/com/sbancuz/plannh/gui/ArrowRouter.java
@@ -123,7 +123,9 @@ public final class ArrowRouter {
             final Request q = requests.get(i);
             // Ports closer than two anchor stubs cannot satisfy the leave-right/arrive-right
             // state machine without looping around themselves; draw the canonical Z directly.
-            if (q.dx - q.sx < 2 * stub && Math.abs(q.dy - q.sy) < 10 * baseCell) {
+            // Forward edges only: for a backward edge the gap is negative, and the Z would cut
+            // straight through every node between the two ports.
+            if (q.dx > q.sx && q.dx - q.sx < 2 * stub && Math.abs(q.dy - q.sy) < 10 * baseCell) {
                 result.put(q.key, fallback(q, stub));
                 continue;
             }

--- a/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
@@ -52,8 +52,6 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     private static final int AUTO_PLACE_STAGGER = 20;
     private static final int HEADER_OFFSET = 24;
     private static final int PORT_HALF = 4;
-    private static final int PORT_SPACING = 18;
-    private static final int PORT_ORIGIN = 10;
     private static final int MIN_GRID_SPACING = 4;
     private static final int ARROW_SIZE = 6;
     private static final int ARROW_MIN_SIZE = 4;
@@ -153,7 +151,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         do {
             final int stagger = slot * AUTO_PLACE_STAGGER;
             x = addedFeedsOrigin ? baseX - stagger : baseX + stagger;
-            y = baseY + slot * (originH + AUTO_PLACE_GAP_Y) + (slot + 1) * (PORT_SPACING / 2);
+            y = baseY + slot * (originH + AUTO_PLACE_GAP_Y) + (slot + 1) * (PortGeometry.SPACING / 2);
             slot++;
         } while (overlapsAnyNode(x, y, originW, originH));
         added.x = x;
@@ -469,14 +467,14 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     }
 
     private int portY(final int index) {
-        return Math.round(((index + 1) * PORT_SPACING + PORT_ORIGIN) * graph.getZoom());
+        return Math.round(PortGeometry.portY(index) * graph.getZoom());
     }
 
     /**
      * World-space (un-zoomed) Y of a port relative to the node's top-left corner.
      */
     private static int portWorldY(final int index) {
-        return (index + 1) * PORT_SPACING + PORT_ORIGIN;
+        return PortGeometry.portY(index);
     }
 
     private int worldWidth(final RecipeNodeWidget w) {
@@ -547,6 +545,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
 
         // The routing input replays headlessly (ArrowRouter is Minecraft-free); dump it at
         // DEBUG on every recompute so any bad-looking route can be rebuilt from the dev log.
+        // TODO: gate routing diagnostics behind a debug flag for the 1.0 cleanup.
         if (PlanNH.LOG.isDebugEnabled()) {
             PlanNH.LOG.debug(reproDump(obstacles, requests));
         }

--- a/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
@@ -325,10 +325,6 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         child(widget);
     }
 
-    /** Pre-auto-layout node positions, so a layout can be undone with shift-click. */
-    @Nullable
-    private Map<UUID, int[]> layoutSnapshot;
-
     public void autoLayoutNodes() {
         if (graph.getNodes()
             .isEmpty()) return;
@@ -366,12 +362,6 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         final Map<UUID, int[]> positions = AutoLayout.layout(boxes, links);
         if (positions.isEmpty()) return;
 
-        final Map<UUID, int[]> snapshot = new HashMap<>();
-        for (final Node node : graph.getNodes()) {
-            snapshot.put(node.id, new int[] { node.x, node.y });
-        }
-        layoutSnapshot = snapshot;
-
         // Anchor the new layout's top-left where the chart's top-left used to be.
         int layoutMinX = Integer.MAX_VALUE;
         int layoutMinY = Integer.MAX_VALUE;
@@ -388,19 +378,6 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
             node.x = pos[0] + offsetX;
             node.y = pos[1] + offsetY;
         }
-        applyNodePositions();
-    }
-
-    /** Restores the positions captured by the last {@link #autoLayoutNodes()} call. */
-    public void restoreLayoutSnapshot() {
-        if (layoutSnapshot == null) return;
-        for (final Node node : graph.getNodes()) {
-            final int[] pos = layoutSnapshot.get(node.id);
-            if (pos == null) continue;
-            node.x = pos[0];
-            node.y = pos[1];
-        }
-        layoutSnapshot = null;
         applyNodePositions();
     }
 

--- a/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
@@ -25,6 +25,7 @@ import com.cleanroommc.modularui.utils.Platform;
 import com.cleanroommc.modularui.widget.ParentWidget;
 import com.cleanroommc.modularui.widget.sizer.Area;
 import com.cleanroommc.modularui.widgets.menu.Menu;
+import com.sbancuz.plannh.Config;
 import com.sbancuz.plannh.PlanNH;
 import com.sbancuz.plannh.data.flowchart.Edge;
 import com.sbancuz.plannh.data.flowchart.Graph;
@@ -501,16 +502,14 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
 
         edgeRoutes.putAll(ARROW_ROUTER.route(obstacles, requests));
 
-        // The routing input replays headlessly (ArrowRouter is Minecraft-free); dump it at
-        // DEBUG on every recompute so any bad-looking route can be rebuilt from the dev log.
-        // TODO: gate routing diagnostics behind a debug flag for the 1.0 cleanup.
-        if (PlanNH.LOG.isDebugEnabled()) {
-            PlanNH.LOG.debug(reproDump(obstacles, requests));
-        }
+        if (!Config.debugRouteDump) return;
+
+        // The routing input replays headlessly (ArrowRouter is Minecraft-free); dump it on
+        // every recompute so any bad-looking route can be rebuilt from the dev log.
+        PlanNH.LOG.info(reproDump(obstacles, requests));
 
         // A route several times longer than its direct distance means the router wrapped
-        // around the chart; dump the full routing input once so the case can be replayed.
-        boolean dumped = false;
+        // around the chart; call it out so the dump above gets looked at.
         for (final ArrowRouter.Request q : requests) {
             final List<int[]> path = edgeRoutes.get(q.key());
             if (path == null) continue;
@@ -520,7 +519,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
             }
             final int direct = Math.abs(q.dx() - q.sx()) + Math.abs(q.dy() - q.sy());
             if (len <= direct * 3 + 200) continue;
-            PlanNH.LOG.warn(
+            PlanNH.LOG.info(
                 "Arrow route wrapped: edge {} ({},{})->({},{}) len={} direct={}",
                 q.key(),
                 q.sx(),
@@ -529,10 +528,6 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
                 q.dy(),
                 len,
                 direct);
-            if (!dumped) {
-                dumped = true;
-                PlanNH.LOG.warn(reproDump(obstacles, requests));
-            }
         }
     }
 

--- a/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
@@ -30,6 +30,7 @@ import com.sbancuz.plannh.data.flowchart.Graph;
 import com.sbancuz.plannh.data.flowchart.Group;
 import com.sbancuz.plannh.data.flowchart.Node;
 import com.sbancuz.plannh.data.flowchart.Note;
+import com.sbancuz.plannh.layout.AutoLayout;
 import com.sbancuz.plannh.nei.NodeLookupContext;
 
 import lombok.Getter;
@@ -323,6 +324,91 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         widget.syncTransform(graph.getZoom(), graph.getPanX(), graph.getPanY());
         nodeWidgets.put(node.id, widget);
         child(widget);
+    }
+
+    /** Pre-auto-layout node positions, so a layout can be undone with shift-click. */
+    @Nullable
+    private Map<UUID, int[]> layoutSnapshot;
+
+    public void autoLayoutNodes() {
+        if (graph.getNodes()
+            .isEmpty()) return;
+
+        final List<AutoLayout.NodeBox> boxes = new ArrayList<>();
+        int anchorX = Integer.MAX_VALUE;
+        int anchorY = Integer.MAX_VALUE;
+        for (final Node node : graph.getNodes()) {
+            final RecipeNodeWidget widget = nodeWidgets.get(node.id);
+            final int width = widget != null ? widget.getWorldWidth() : 120;
+            final int height = widget != null ? widget.getWorldHeight() : 80;
+            boxes.add(
+                new AutoLayout.NodeBox(
+                    node.id,
+                    node.machineName == null ? "" : node.machineName,
+                    width,
+                    height,
+                    node.inputs.size(),
+                    node.outputs.size()));
+            anchorX = Math.min(anchorX, node.x);
+            anchorY = Math.min(anchorY, node.y);
+        }
+
+        final List<AutoLayout.Link> links = new ArrayList<>();
+        for (final Edge edge : graph.getEdges()) {
+            links.add(
+                new AutoLayout.Link(
+                    edge.sourceNodeId,
+                    edge.sourceOutputIndex,
+                    edge.targetNodeId,
+                    edge.targetInputIndex));
+        }
+
+        final Map<UUID, int[]> positions = AutoLayout.layout(boxes, links);
+        if (positions.isEmpty()) return;
+
+        final Map<UUID, int[]> snapshot = new HashMap<>();
+        for (final Node node : graph.getNodes()) {
+            snapshot.put(node.id, new int[] { node.x, node.y });
+        }
+        layoutSnapshot = snapshot;
+
+        // Anchor the new layout's top-left where the chart's top-left used to be.
+        int layoutMinX = Integer.MAX_VALUE;
+        int layoutMinY = Integer.MAX_VALUE;
+        for (final int[] pos : positions.values()) {
+            layoutMinX = Math.min(layoutMinX, pos[0]);
+            layoutMinY = Math.min(layoutMinY, pos[1]);
+        }
+        final int offsetX = anchorX - layoutMinX;
+        final int offsetY = anchorY - layoutMinY;
+
+        for (final Node node : graph.getNodes()) {
+            final int[] pos = positions.get(node.id);
+            if (pos == null) continue;
+            node.x = pos[0] + offsetX;
+            node.y = pos[1] + offsetY;
+        }
+        applyNodePositions();
+    }
+
+    /** Restores the positions captured by the last {@link #autoLayoutNodes()} call. */
+    public void restoreLayoutSnapshot() {
+        if (layoutSnapshot == null) return;
+        for (final Node node : graph.getNodes()) {
+            final int[] pos = layoutSnapshot.get(node.id);
+            if (pos == null) continue;
+            node.x = pos[0];
+            node.y = pos[1];
+        }
+        layoutSnapshot = null;
+        applyNodePositions();
+    }
+
+    private void applyNodePositions() {
+        for (final RecipeNodeWidget widget : nodeWidgets.values()) {
+            widget.syncTransform(graph.getZoom(), graph.getPanX(), graph.getPanY());
+        }
+        recheckMembershipAndFit();
     }
 
     @Override

--- a/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
@@ -25,6 +25,7 @@ import com.cleanroommc.modularui.utils.Platform;
 import com.cleanroommc.modularui.widget.ParentWidget;
 import com.cleanroommc.modularui.widget.sizer.Area;
 import com.cleanroommc.modularui.widgets.menu.Menu;
+import com.sbancuz.plannh.PlanNH;
 import com.sbancuz.plannh.data.flowchart.Edge;
 import com.sbancuz.plannh.data.flowchart.Graph;
 import com.sbancuz.plannh.data.flowchart.Group;
@@ -339,6 +340,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         int anchorY = Integer.MAX_VALUE;
         for (final Node node : graph.getNodes()) {
             final RecipeNodeWidget widget = nodeWidgets.get(node.id);
+            if (widget != null) widget.ensureRecipeHandler();
             final int width = widget != null ? widget.getWorldWidth() : 120;
             final int height = widget != null ? widget.getWorldHeight() : 80;
             boxes.add(
@@ -542,6 +544,65 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         }
 
         edgeRoutes.putAll(ARROW_ROUTER.route(obstacles, requests));
+
+        // The routing input replays headlessly (ArrowRouter is Minecraft-free); dump it at
+        // DEBUG on every recompute so any bad-looking route can be rebuilt from the dev log.
+        if (PlanNH.LOG.isDebugEnabled()) {
+            PlanNH.LOG.debug(reproDump(obstacles, requests));
+        }
+
+        // A route several times longer than its direct distance means the router wrapped
+        // around the chart; dump the full routing input once so the case can be replayed.
+        boolean dumped = false;
+        for (final ArrowRouter.Request q : requests) {
+            final List<int[]> path = edgeRoutes.get(q.key());
+            if (path == null) continue;
+            int len = 0;
+            for (int i = 1; i < path.size(); i++) {
+                len += Math.abs(path.get(i)[0] - path.get(i - 1)[0]) + Math.abs(path.get(i)[1] - path.get(i - 1)[1]);
+            }
+            final int direct = Math.abs(q.dx() - q.sx()) + Math.abs(q.dy() - q.sy());
+            if (len <= direct * 3 + 200) continue;
+            PlanNH.LOG.warn(
+                "Arrow route wrapped: edge {} ({},{})->({},{}) len={} direct={}",
+                q.key(),
+                q.sx(),
+                q.sy(),
+                q.dx(),
+                q.dy(),
+                len,
+                direct);
+            if (!dumped) {
+                dumped = true;
+                PlanNH.LOG.warn(reproDump(obstacles, requests));
+            }
+        }
+    }
+
+    private static String reproDump(final List<ArrowRouter.Rect> obstacles, final List<ArrowRouter.Request> requests) {
+        final StringBuilder sb = new StringBuilder("Route repro: obstacles=");
+        for (final ArrowRouter.Rect r : obstacles) {
+            sb.append(r.x())
+                .append(',')
+                .append(r.y())
+                .append(',')
+                .append(r.w())
+                .append(',')
+                .append(r.h())
+                .append(';');
+        }
+        sb.append(" requests=");
+        for (final ArrowRouter.Request r : requests) {
+            sb.append(r.sx())
+                .append(',')
+                .append(r.sy())
+                .append(',')
+                .append(r.dx())
+                .append(',')
+                .append(r.dy())
+                .append(';');
+        }
+        return sb.toString();
     }
 
     private long computeRouteSignature() {

--- a/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
@@ -140,8 +140,8 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
      */
     public void placeBesideOrigin(final Node added, final Node origin, final boolean addedFeedsOrigin) {
         final RecipeNodeWidget originWidget = nodeWidgets.get(origin.id);
-        final int originW = originWidget != null ? originWidget.getWorldWidth() : NODE_W_ESTIMATE;
-        final int originH = originWidget != null ? originWidget.getWorldHeight() : NODE_H_ESTIMATE;
+        final int originW = originWidget != null ? originWidget.worldWidth() : NODE_W_ESTIMATE;
+        final int originH = originWidget != null ? originWidget.worldHeight() : NODE_H_ESTIMATE;
         final int baseX = Math
             .round(addedFeedsOrigin ? origin.x - originW - AUTO_PLACE_GAP_X : origin.x + originW + AUTO_PLACE_GAP_X);
         final int baseY = Math.round(origin.y);
@@ -161,7 +161,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     private boolean overlapsAnyNode(final int x, final int y, final int w, final int h) {
         for (final RecipeNodeWidget widget : nodeWidgets.values()) {
             final Node n = widget.getNode();
-            if (x < n.x + widget.getWorldWidth() && n.x < x + w && y < n.y + widget.getWorldHeight() && n.y < y + h) {
+            if (x < n.x + widget.worldWidth() && n.x < x + w && y < n.y + widget.worldHeight() && n.y < y + h) {
                 return true;
             }
         }
@@ -329,37 +329,18 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         if (graph.getNodes()
             .isEmpty()) return;
 
-        final List<AutoLayout.NodeBox> boxes = new ArrayList<>();
+        // The widgets ARE the layout input (they implement LayoutNode); measure them first
+        // because MUI2 culls off-viewport widgets and unmeasured nodes report stub sizes.
         int anchorX = Integer.MAX_VALUE;
         int anchorY = Integer.MAX_VALUE;
         for (final Node node : graph.getNodes()) {
             final RecipeNodeWidget widget = nodeWidgets.get(node.id);
             if (widget != null) widget.ensureRecipeHandler();
-            final int width = widget != null ? widget.getWorldWidth() : 120;
-            final int height = widget != null ? widget.getWorldHeight() : 80;
-            boxes.add(
-                new AutoLayout.NodeBox(
-                    node.id,
-                    node.machineName == null ? "" : node.machineName,
-                    width,
-                    height,
-                    node.inputs.size(),
-                    node.outputs.size()));
             anchorX = Math.min(anchorX, node.x);
             anchorY = Math.min(anchorY, node.y);
         }
 
-        final List<AutoLayout.Link> links = new ArrayList<>();
-        for (final Edge edge : graph.getEdges()) {
-            links.add(
-                new AutoLayout.Link(
-                    edge.sourceNodeId,
-                    edge.sourceOutputIndex,
-                    edge.targetNodeId,
-                    edge.targetInputIndex));
-        }
-
-        final Map<UUID, int[]> positions = AutoLayout.layout(boxes, links);
+        final Map<UUID, int[]> positions = AutoLayout.layout(nodeWidgets.values(), graph.getEdges());
         if (positions.isEmpty()) return;
 
         // Anchor the new layout's top-left where the chart's top-left used to be.
@@ -455,11 +436,11 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     }
 
     private int worldWidth(final RecipeNodeWidget w) {
-        return w.getWorldWidth();
+        return w.worldWidth();
     }
 
     private int worldHeight(final RecipeNodeWidget w) {
-        return w.getWorldHeight();
+        return w.worldHeight();
     }
 
     /**
@@ -906,9 +887,9 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
                 final int localMy = worldDragMy - Math.round(widget.getNode().y);
                 int port = widget.getInputPortAt(localMx, localMy);
                 if (port < 0 && localMx >= 0
-                    && localMx < widget.getWorldWidth()
+                    && localMx < widget.worldWidth()
                     && localMy >= 0
-                    && localMy < widget.getWorldHeight()) {
+                    && localMy < widget.worldHeight()) {
                     // Dropped on the node body: wire into a matching input automatically.
                     port = graph.findCompatibleInput(srcWidget.getNode(), edgeSourcePortIndex, widget.getNode());
                 }

--- a/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
@@ -390,13 +390,17 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
         final int offsetX = anchorX - layoutMinX;
         final int offsetY = anchorY - layoutMinY;
 
-        for (final Node node : graph.getNodes()) {
-            final int[] pos = positions.get(node.id);
-            if (pos == null) continue;
-            node.x = pos[0] + offsetX;
-            node.y = pos[1] + offsetY;
-        }
-        applyNodePositions();
+        // Bracketed only from here: a layout that threw or produced nothing left the chart alone,
+        // and an undo entry for a no-op move would make the button look like it did something.
+        PlanAPI.recordEdit(graph, () -> {
+            for (final Node node : graph.getNodes()) {
+                final int[] pos = positions.get(node.id);
+                if (pos == null) continue;
+                node.x = pos[0] + offsetX;
+                node.y = pos[1] + offsetY;
+            }
+            applyNodePositions();
+        });
     }
 
     private void applyNodePositions() {

--- a/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
@@ -341,7 +341,17 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
             anchorY = Math.min(anchorY, node.y);
         }
 
-        final Map<UUID, int[]> positions = AutoLayout.layout(nodeWidgets.values(), graph.getEdges());
+        // ELK reports bad option/graph combinations by throwing, and its node placement recurses
+        // per path, so a pathological chart can exhaust the stack. Both would otherwise leave a
+        // mouse handler and crash the client with the chart unsaved; the chart is worth more than
+        // the layout, so log and keep the current positions.
+        final Map<UUID, int[]> positions;
+        try {
+            positions = AutoLayout.layout(nodeWidgets.values(), graph.getEdges());
+        } catch (final RuntimeException | StackOverflowError e) {
+            PlanNH.LOG.error("Auto-layout failed; node positions left unchanged", e);
+            return;
+        }
         if (positions.isEmpty()) return;
 
         // Anchor the new layout's top-left where the chart's top-left used to be.

--- a/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
+++ b/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
@@ -165,15 +165,9 @@ public class FlowchartScreen extends ModularScreen {
                         .childPadding(2)
                         .child(
                             new ButtonWidget<>().overlay(IKey.str("AL"))
-                                .tooltipStatic(
-                                    t -> t.addLine(IKey.str("Auto layout"))
-                                        .addLine(IKey.str("Shift-click to restore previous positions")))
+                                .tooltipStatic(t -> t.addLine(IKey.str("Auto layout")))
                                 .onMousePressed(_ -> {
-                                    if (Interactable.hasShiftDown()) {
-                                        canvas.restoreLayoutSnapshot();
-                                    } else {
-                                        canvas.autoLayoutNodes();
-                                    }
+                                    canvas.autoLayoutNodes();
                                     PlanAPI.save();
                                     return true;
                                 }))

--- a/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
+++ b/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
@@ -125,10 +125,7 @@ public class FlowchartScreen extends ModularScreen {
         mainColumn.child(
             Flow.row()
                 .mainAxisAlignment(Alignment.MainAxis.SPACE_BETWEEN)
-                // MUI2's default widget height is 18: a 16-tall row makes the coverChildren
-                // button rows overflow the cross axis, and SimpleFlow then logs a padding
-                // warning for each of them on EVERY relayout (the log-spam bug).
-                .height(18)
+                .height(16)
                 .fullWidth()
                 .child(
                     Flow.row()

--- a/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
+++ b/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
@@ -164,6 +164,20 @@ public class FlowchartScreen extends ModularScreen {
                         .coverChildren()
                         .childPadding(2)
                         .child(
+                            new ButtonWidget<>().overlay(IKey.str("AL"))
+                                .tooltipStatic(
+                                    t -> t.addLine(IKey.str("Auto layout"))
+                                        .addLine(IKey.str("Shift-click to restore previous positions")))
+                                .onMousePressed(_ -> {
+                                    if (Interactable.hasShiftDown()) {
+                                        canvas.restoreLayoutSnapshot();
+                                    } else {
+                                        canvas.autoLayoutNodes();
+                                    }
+                                    PlanAPI.save();
+                                    return true;
+                                }))
+                        .child(
                             new ButtonWidget<>().overlay(IKey.str("S2G"))
                                 .onMousePressed(_ -> {
                                     final Graph g = canvas.getGraph();

--- a/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
+++ b/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
@@ -125,7 +125,10 @@ public class FlowchartScreen extends ModularScreen {
         mainColumn.child(
             Flow.row()
                 .mainAxisAlignment(Alignment.MainAxis.SPACE_BETWEEN)
-                .height(16)
+                // MUI2's default widget height is 18: a 16-tall row makes the coverChildren
+                // button rows overflow the cross axis, and SimpleFlow then logs a padding
+                // warning for each of them on EVERY relayout (the log-spam bug).
+                .height(18)
                 .fullWidth()
                 .child(
                     Flow.row()

--- a/src/main/java/com/sbancuz/plannh/gui/PortGeometry.java
+++ b/src/main/java/com/sbancuz/plannh/gui/PortGeometry.java
@@ -1,0 +1,19 @@
+package com.sbancuz.plannh.gui;
+
+/**
+ * Pin placement, the single authority for everything that draws or measures ports: pin
+ * {@code i} sits at {@code y = (i + 1) * SPACING + ORIGIN} on its node edge. Deliberately
+ * Minecraft-free so headless code (AutoLayout) can share it.
+ */
+public final class PortGeometry {
+
+    public static final int SPACING = 18;
+    public static final int ORIGIN = 10;
+
+    private PortGeometry() {}
+
+    /** World-space Y of a port relative to its node's top edge. */
+    public static int portY(final int index) {
+        return (index + 1) * SPACING + ORIGIN;
+    }
+}

--- a/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
@@ -190,7 +190,12 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
         return lines * LINE_H + 6;
     }
 
-    private void ensureRecipeHandler() {
+    /**
+     * Loads the NEI handler that determines this widget's real size. Lazy - normally first
+     * draw does it, but MUI2 culls off-viewport widgets, so anything measuring node sizes
+     * (auto-layout) must call this first or off-screen nodes report stub dimensions.
+     */
+    void ensureRecipeHandler() {
         if (handlerRef != null || handlerInitFailed) return;
 
         final RecipeHandlerRef ref = RecipeHandlerRef.of(node.recipeId);

--- a/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
@@ -47,8 +47,6 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
     private static final int CLOSE_MARGIN = 2;
     private static final int PORT_SIZE = 8;
     private static final int PORT_HALF = PORT_SIZE / 2;
-    private static final int PORT_SPACING = 18;
-    private static final int PORT_ORIGIN = 10;
     private static final int LINE_H = 11;
     private static final int ALPHA_BAR = 180;
 
@@ -404,7 +402,7 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
     }
 
     private int portTopY(final int index) {
-        return (index + 1) * PORT_SPACING + PORT_ORIGIN;
+        return PortGeometry.portY(index);
     }
 
     private void drawPorts() {

--- a/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
@@ -4,6 +4,7 @@ import static org.lwjgl.opengl.GL11.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -28,6 +29,7 @@ import com.sbancuz.plannh.data.flowchart.Balancer.NodeBalance;
 import com.sbancuz.plannh.data.flowchart.Group;
 import com.sbancuz.plannh.data.flowchart.Node;
 import com.sbancuz.plannh.data.flowchart.Port;
+import com.sbancuz.plannh.layout.AutoLayout;
 import com.sbancuz.plannh.nei.NodeLookupContext;
 
 import codechicken.nei.PositionedStack;
@@ -39,7 +41,8 @@ import codechicken.nei.recipe.NEIRecipeWidget;
 import codechicken.nei.recipe.RecipeHandlerRef;
 import lombok.Getter;
 
-public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Interactable, RecipeViewerIngredientProvider {
+public class RecipeNodeWidget extends Widget<RecipeNodeWidget>
+    implements Interactable, RecipeViewerIngredientProvider, AutoLayout.LayoutNode {
 
     private static final int BASE_W = 120;
     private static final int BASE_H = 80;
@@ -152,14 +155,36 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
         size(BASE_W, BASE_H);
     }
 
-    int getWorldWidth() {
+    @Override
+    public UUID id() {
+        return node.id;
+    }
+
+    @Override
+    public String machineName() {
+        return node.machineName;
+    }
+
+    @Override
+    public int inputCount() {
+        return node.inputs.size();
+    }
+
+    @Override
+    public int outputCount() {
+        return node.outputs.size();
+    }
+
+    @Override
+    public int worldWidth() {
         if (handlerRef != null && neiWidget != null) {
             return neiWidget.w + NEI_PAD_W + NEI_BORDER;
         }
         return BASE_W;
     }
 
-    int getWorldHeight() {
+    @Override
+    public int worldHeight() {
         if (handlerRef != null && neiWidget != null) {
             return neiWidget.h + NEI_PAD_H + calcInfoHeight() + computeConfigPanelHeight() + NEI_BORDER;
         }
@@ -193,7 +218,7 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
      * draw does it, but MUI2 culls off-viewport widgets, so anything measuring node sizes
      * (auto-layout) must call this first or off-screen nodes report stub dimensions.
      */
-    void ensureRecipeHandler() {
+    public void ensureRecipeHandler() {
         if (handlerRef != null || handlerInitFailed) return;
 
         final RecipeHandlerRef ref = RecipeHandlerRef.of(node.recipeId);
@@ -223,7 +248,7 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
 
     private void resizeForZoom(final float z) {
         if (handlerRef != null && neiWidget != null) {
-            final int cw = getWorldWidth() - NEI_BORDER;
+            final int cw = worldWidth() - NEI_BORDER;
             final int ch = neiWidget.h + NEI_PAD_H + calcInfoHeight() + computeConfigPanelHeight();
             setAreaSize(cw + NEI_BORDER, ch + NEI_BORDER);
         } else {

--- a/src/main/java/com/sbancuz/plannh/layout/AutoLayout.java
+++ b/src/main/java/com/sbancuz/plannh/layout/AutoLayout.java
@@ -2,6 +2,7 @@ package com.sbancuz.plannh.layout;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Deque;
@@ -30,6 +31,7 @@ import org.eclipse.elk.graph.ElkNode;
 import org.eclipse.elk.graph.ElkPort;
 import org.eclipse.elk.graph.util.ElkGraphUtil;
 
+import com.sbancuz.plannh.data.flowchart.Edge;
 import com.sbancuz.plannh.gui.PortGeometry;
 
 /**
@@ -52,11 +54,25 @@ import com.sbancuz.plannh.gui.PortGeometry;
  */
 public final class AutoLayout {
 
-    /** World-space size and port counts of one machine node. */
-    public record NodeBox(UUID id, String name, int width, int height, int inputPorts, int outputPorts) {}
+    /**
+     * Read view of one machine node: identity, world-space size, and port counts. The GUI's node
+     * widget implements this directly, so layout consumes the existing objects instead of a
+     * copied model, while this class stays free of Minecraft imports.
+     */
+    public interface LayoutNode {
 
-    /** One drawn edge: source node output port -> target node input port. */
-    public record Link(UUID source, int outputIndex, UUID target, int inputIndex) {}
+        UUID id();
+
+        String machineName();
+
+        int worldWidth();
+
+        int worldHeight();
+
+        int inputCount();
+
+        int outputCount();
+    }
 
     /** Nodes above this count switch to the scalable placement strategy. */
     private static final int BIG_GRAPH_NODES = 300;
@@ -83,11 +99,11 @@ public final class AutoLayout {
      * Computes new world-space top-left positions for every node. Positions are relative to an
      * arbitrary origin; callers anchor the result wherever they want.
      */
-    public static Map<UUID, int[]> layout(final List<NodeBox> nodes, final List<Link> links) {
+    public static Map<UUID, int[]> layout(final Collection<? extends LayoutNode> nodes, final Collection<Edge> links) {
         final Map<UUID, int[]> result = new HashMap<>();
         if (nodes.isEmpty()) return result;
 
-        final List<NodeBox> ordered = canonicalOrder(nodes, links);
+        final List<LayoutNode> ordered = canonicalOrder(nodes, links);
 
         // ELK consumes edges in model order too, so links follow the node canonicalization:
         // source position, then port, then target position.
@@ -98,12 +114,12 @@ public final class AutoLayout {
                     .id(),
                 i);
         }
-        final List<Link> orderedLinks = new ArrayList<>(links);
+        final List<Edge> orderedLinks = new ArrayList<>(links);
         orderedLinks.sort(
-            Comparator.<Link>comparingInt(link -> orderIndex.getOrDefault(link.source(), -1))
-                .thenComparingInt(Link::outputIndex)
-                .thenComparingInt(link -> orderIndex.getOrDefault(link.target(), -1))
-                .thenComparingInt(Link::inputIndex));
+            Comparator.<Edge>comparingInt(link -> orderIndex.getOrDefault(link.sourceNodeId, -1))
+                .thenComparingInt(link -> link.sourceOutputIndex)
+                .thenComparingInt(link -> orderIndex.getOrDefault(link.targetNodeId, -1))
+                .thenComparingInt(link -> link.targetInputIndex));
 
         final ElkNode root = ElkGraphUtil.createGraph();
         root.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
@@ -134,44 +150,44 @@ public final class AutoLayout {
         final Map<UUID, ElkPort[]> inPorts = new HashMap<>();
         final Map<UUID, ElkPort[]> outPorts = new HashMap<>();
 
-        for (final NodeBox box : ordered) {
+        for (final LayoutNode node : ordered) {
             final ElkNode n = ElkGraphUtil.createNode(root);
-            n.setWidth(box.width());
-            n.setHeight(box.height());
+            n.setWidth(node.worldWidth());
+            n.setHeight(node.worldHeight());
             // Real pin coordinates, not just sides: node placement then straightens edges
             // against the positions the canvas actually draws, so single connections line up
             // horizontally instead of jogging by ELK's invented port spread.
             n.setProperty(CoreOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_POS);
-            elkNodes.put(box.id(), n);
+            elkNodes.put(node.id(), n);
 
-            final ElkPort[] outs = new ElkPort[box.outputPorts()];
-            for (int i = 0; i < box.outputPorts(); i++) {
+            final ElkPort[] outs = new ElkPort[node.outputCount()];
+            for (int i = 0; i < node.outputCount(); i++) {
                 final ElkPort p = ElkGraphUtil.createPort(n);
                 p.setProperty(CoreOptions.PORT_SIDE, PortSide.EAST);
-                p.setX(box.width());
+                p.setX(node.worldWidth());
                 p.setY(PortGeometry.portY(i));
                 outs[i] = p;
             }
-            outPorts.put(box.id(), outs);
+            outPorts.put(node.id(), outs);
 
-            final ElkPort[] ins = new ElkPort[box.inputPorts()];
-            for (int i = 0; i < box.inputPorts(); i++) {
+            final ElkPort[] ins = new ElkPort[node.inputCount()];
+            for (int i = 0; i < node.inputCount(); i++) {
                 final ElkPort p = ElkGraphUtil.createPort(n);
                 p.setProperty(CoreOptions.PORT_SIDE, PortSide.WEST);
                 p.setX(0);
                 p.setY(PortGeometry.portY(i));
                 ins[i] = p;
             }
-            inPorts.put(box.id(), ins);
+            inPorts.put(node.id(), ins);
         }
 
-        for (final Link link : orderedLinks) {
-            final ElkPort[] outs = outPorts.get(link.source());
-            final ElkPort[] ins = inPorts.get(link.target());
+        for (final Edge link : orderedLinks) {
+            final ElkPort[] outs = outPorts.get(link.sourceNodeId);
+            final ElkPort[] ins = inPorts.get(link.targetNodeId);
             if (outs == null || ins == null) continue;
-            if (link.outputIndex() < 0 || link.outputIndex() >= outs.length) continue;
-            if (link.inputIndex() < 0 || link.inputIndex() >= ins.length) continue;
-            ElkGraphUtil.createSimpleEdge(outs[link.outputIndex()], ins[link.inputIndex()]);
+            if (link.sourceOutputIndex < 0 || link.sourceOutputIndex >= outs.length) continue;
+            if (link.targetInputIndex < 0 || link.targetInputIndex >= ins.length) continue;
+            ElkGraphUtil.createSimpleEdge(outs[link.sourceOutputIndex], ins[link.targetInputIndex]);
         }
 
         new LayeredLayoutProvider().layout(root, new BasicProgressMonitor());
@@ -187,12 +203,12 @@ public final class AutoLayout {
      * Orders nodes by SCC-condensation height (sources first), then name, then wiring color,
      * then id, so the layout is independent of the order recipes were added in NEI.
      */
-    static List<NodeBox> canonicalOrder(final List<NodeBox> nodes, final List<Link> links) {
+    static List<LayoutNode> canonicalOrder(final Collection<? extends LayoutNode> nodes, final Collection<Edge> links) {
         final Map<UUID, List<UUID>> adjacency = new HashMap<>();
-        for (final NodeBox box : nodes) adjacency.put(box.id(), new ArrayList<>());
-        for (final Link link : links) {
-            final List<UUID> next = adjacency.get(link.source());
-            if (next != null && adjacency.containsKey(link.target())) next.add(link.target());
+        for (final LayoutNode node : nodes) adjacency.put(node.id(), new ArrayList<>());
+        for (final Edge link : links) {
+            final List<UUID> next = adjacency.get(link.sourceNodeId);
+            if (next != null && adjacency.containsKey(link.targetNodeId)) next.add(link.targetNodeId);
         }
 
         final Map<UUID, Integer> sccOf = tarjanScc(adjacency);
@@ -204,9 +220,9 @@ public final class AutoLayout {
             sccAdjacency.putIfAbsent(scc, new ArrayList<>());
             inDegree.putIfAbsent(scc, 0);
         }
-        for (final Link link : links) {
-            final Integer a = sccOf.get(link.source());
-            final Integer b = sccOf.get(link.target());
+        for (final Edge link : links) {
+            final Integer a = sccOf.get(link.sourceNodeId);
+            final Integer b = sccOf.get(link.targetNodeId);
             if (a == null || b == null || a.equals(b)) continue;
             sccAdjacency.get(a)
                 .add(b);
@@ -233,8 +249,8 @@ public final class AutoLayout {
         }
 
         final Map<UUID, Integer> nodeHeight = new HashMap<>();
-        for (final NodeBox box : nodes) {
-            nodeHeight.put(box.id(), height.getOrDefault(sccOf.get(box.id()), 0));
+        for (final LayoutNode node : nodes) {
+            nodeHeight.put(node.id(), height.getOrDefault(sccOf.get(node.id()), 0));
         }
 
         // Ids are random at creation, so an id tiebreak alone would let two same-name machines at
@@ -242,18 +258,18 @@ public final class AutoLayout {
         // first leaves the id ordering only true structural twins, and swapping twins does not
         // change the picture.
         final Map<UUID, String> names = new HashMap<>();
-        for (final NodeBox box : nodes) {
-            names.put(box.id(), box.name() == null ? "" : box.name());
+        for (final LayoutNode node : nodes) {
+            names.put(node.id(), node.machineName() == null ? "" : node.machineName());
         }
         final Map<UUID, Integer> color = wiringColors(nodes, links, names, nodeHeight);
 
-        final List<NodeBox> ordered = new ArrayList<>(nodes);
+        final List<LayoutNode> ordered = new ArrayList<>(nodes);
         ordered.sort(
-            Comparator.<NodeBox>comparingInt(box -> nodeHeight.get(box.id()))
-                .thenComparing(box -> names.get(box.id()))
-                .thenComparingInt(box -> color.get(box.id()))
+            Comparator.<LayoutNode>comparingInt(node -> nodeHeight.get(node.id()))
+                .thenComparing(node -> names.get(node.id()))
+                .thenComparingInt(node -> color.get(node.id()))
                 .thenComparing(
-                    box -> box.id()
+                    node -> node.id()
                         .toString()));
         return ordered;
     }
@@ -267,47 +283,49 @@ public final class AutoLayout {
      * round before the fixpoint splits a color class, which bounds the work by
      * O(V * (V + E) * log V); real charts settle within a few rounds.
      */
-    private static Map<UUID, Integer> wiringColors(final List<NodeBox> nodes, final List<Link> links,
-        final Map<UUID, String> names, final Map<UUID, Integer> nodeHeight) {
+    private static Map<UUID, Integer> wiringColors(final Collection<? extends LayoutNode> nodes,
+        final Collection<Edge> links, final Map<UUID, String> names, final Map<UUID, Integer> nodeHeight) {
         record LinkEnd(String head, UUID peer) {}
 
         final Map<UUID, List<LinkEnd>> ends = new HashMap<>();
-        for (final NodeBox box : nodes) {
-            ends.put(box.id(), new ArrayList<>());
+        for (final LayoutNode node : nodes) {
+            ends.put(node.id(), new ArrayList<>());
         }
-        for (final Link link : links) {
-            final List<LinkEnd> atSource = ends.get(link.source());
-            final List<LinkEnd> atTarget = ends.get(link.target());
+        for (final Edge link : links) {
+            final List<LinkEnd> atSource = ends.get(link.sourceNodeId);
+            final List<LinkEnd> atTarget = ends.get(link.targetNodeId);
             if (atSource == null || atTarget == null) continue;
-            atSource.add(new LinkEnd("o" + link.outputIndex() + ":" + link.inputIndex() + ">", link.target()));
-            atTarget.add(new LinkEnd("i" + link.inputIndex() + ":" + link.outputIndex() + "<", link.source()));
+            atSource
+                .add(new LinkEnd("o" + link.sourceOutputIndex + ":" + link.targetInputIndex + ">", link.targetNodeId));
+            atTarget
+                .add(new LinkEnd("i" + link.targetInputIndex + ":" + link.sourceOutputIndex + "<", link.sourceNodeId));
         }
 
         Map<UUID, Integer> colors = null;
         int distinct = 0;
         while (true) {
             final Map<UUID, String> signatures = new HashMap<>();
-            for (final NodeBox box : nodes) {
+            for (final LayoutNode node : nodes) {
                 if (colors == null) {
                     signatures.put(
-                        box.id(),
-                        box.width() + "x"
-                            + box.height()
+                        node.id(),
+                        node.worldWidth() + "x"
+                            + node.worldHeight()
                             + ":"
-                            + box.inputPorts()
+                            + node.inputCount()
                             + ":"
-                            + box.outputPorts()
+                            + node.outputCount()
                             + ":"
-                            + nodeHeight.get(box.id())
+                            + nodeHeight.get(node.id())
                             + ":"
-                            + names.get(box.id()));
+                            + names.get(node.id()));
                 } else {
                     final List<String> entries = new ArrayList<>();
-                    for (final LinkEnd end : ends.get(box.id())) {
+                    for (final LinkEnd end : ends.get(node.id())) {
                         entries.add(end.head() + colors.get(end.peer()));
                     }
                     Collections.sort(entries);
-                    signatures.put(box.id(), colors.get(box.id()) + "|" + String.join(",", entries));
+                    signatures.put(node.id(), colors.get(node.id()) + "|" + String.join(",", entries));
                 }
             }
 

--- a/src/main/java/com/sbancuz/plannh/layout/AutoLayout.java
+++ b/src/main/java/com/sbancuz/plannh/layout/AutoLayout.java
@@ -2,11 +2,13 @@ package com.sbancuz.plannh.layout;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeSet;
 import java.util.UUID;
 
 import org.eclipse.elk.alg.layered.LayeredLayoutProvider;
@@ -42,7 +44,8 @@ import com.sbancuz.plannh.gui.PortGeometry;
  * <p>
  * Layered engines consume nodes in model order, so the same chart built in a different NEI click
  * order would lay out differently. Nodes are therefore canonicalized first: SCC condensation
- * height, then name, then id. Same graph, same layout, always.
+ * height, then name, then wiring, then id - and links follow the node order. Same graph, same
+ * layout, always.
  *
  * <p>
  * This class is deliberately free of Minecraft/NEI imports so it can be exercised headlessly.
@@ -85,6 +88,22 @@ public final class AutoLayout {
         if (nodes.isEmpty()) return result;
 
         final List<NodeBox> ordered = canonicalOrder(nodes, links);
+
+        // ELK consumes edges in model order too, so links follow the node canonicalization:
+        // source position, then port, then target position.
+        final Map<UUID, Integer> orderIndex = new HashMap<>();
+        for (int i = 0; i < ordered.size(); i++) {
+            orderIndex.put(
+                ordered.get(i)
+                    .id(),
+                i);
+        }
+        final List<Link> orderedLinks = new ArrayList<>(links);
+        orderedLinks.sort(
+            Comparator.<Link>comparingInt(link -> orderIndex.getOrDefault(link.source(), -1))
+                .thenComparingInt(Link::outputIndex)
+                .thenComparingInt(link -> orderIndex.getOrDefault(link.target(), -1))
+                .thenComparingInt(Link::inputIndex));
 
         final ElkNode root = ElkGraphUtil.createGraph();
         root.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
@@ -146,7 +165,7 @@ public final class AutoLayout {
             inPorts.put(box.id(), ins);
         }
 
-        for (final Link link : links) {
+        for (final Link link : orderedLinks) {
             final ElkPort[] outs = outPorts.get(link.source());
             final ElkPort[] ins = inPorts.get(link.target());
             if (outs == null || ins == null) continue;
@@ -165,8 +184,8 @@ public final class AutoLayout {
     }
 
     /**
-     * Orders nodes by SCC-condensation height (sources first), then name, then id, so the layout
-     * is independent of the order recipes were added in NEI.
+     * Orders nodes by SCC-condensation height (sources first), then name, then wiring color,
+     * then id, so the layout is independent of the order recipes were added in NEI.
      */
     static List<NodeBox> canonicalOrder(final List<NodeBox> nodes, final List<Link> links) {
         final Map<UUID, List<UUID>> adjacency = new HashMap<>();
@@ -213,14 +232,102 @@ public final class AutoLayout {
             }
         }
 
+        final Map<UUID, Integer> nodeHeight = new HashMap<>();
+        for (final NodeBox box : nodes) {
+            nodeHeight.put(box.id(), height.getOrDefault(sccOf.get(box.id()), 0));
+        }
+
+        // Ids are random at creation, so an id tiebreak alone would let two same-name machines at
+        // the same height swap between rebuilds of the same chart. Tie-breaking on wiring colors
+        // first leaves the id ordering only true structural twins, and swapping twins does not
+        // change the picture.
+        final Map<UUID, String> names = new HashMap<>();
+        for (final NodeBox box : nodes) {
+            names.put(box.id(), box.name() == null ? "" : box.name());
+        }
+        final Map<UUID, Integer> color = wiringColors(nodes, links, names, nodeHeight);
+
         final List<NodeBox> ordered = new ArrayList<>(nodes);
         ordered.sort(
-            Comparator.<NodeBox>comparingInt(box -> height.getOrDefault(sccOf.get(box.id()), 0))
-                .thenComparing(box -> box.name() == null ? "" : box.name())
+            Comparator.<NodeBox>comparingInt(box -> nodeHeight.get(box.id()))
+                .thenComparing(box -> names.get(box.id()))
+                .thenComparingInt(box -> color.get(box.id()))
                 .thenComparing(
                     box -> box.id()
                         .toString()));
         return ordered;
+    }
+
+    /**
+     * Canonical wiring color per node by iterated neighborhood refinement. Nodes start colored
+     * by shape - size, port counts, height, name - then are repeatedly recolored by their own
+     * color plus the sorted list of (own port, direction, peer color) link entries, until the
+     * partition stops splitting. Two nodes share a final color only if no chain of links
+     * distinguishes them, so an id tiebreak after this orders only interchangeable twins. Every
+     * round before the fixpoint splits a color class, which bounds the work by
+     * O(V * (V + E) * log V); real charts settle within a few rounds.
+     */
+    private static Map<UUID, Integer> wiringColors(final List<NodeBox> nodes, final List<Link> links,
+        final Map<UUID, String> names, final Map<UUID, Integer> nodeHeight) {
+        record LinkEnd(String head, UUID peer) {}
+
+        final Map<UUID, List<LinkEnd>> ends = new HashMap<>();
+        for (final NodeBox box : nodes) {
+            ends.put(box.id(), new ArrayList<>());
+        }
+        for (final Link link : links) {
+            final List<LinkEnd> atSource = ends.get(link.source());
+            final List<LinkEnd> atTarget = ends.get(link.target());
+            if (atSource == null || atTarget == null) continue;
+            atSource.add(new LinkEnd("o" + link.outputIndex() + ":" + link.inputIndex() + ">", link.target()));
+            atTarget.add(new LinkEnd("i" + link.inputIndex() + ":" + link.outputIndex() + "<", link.source()));
+        }
+
+        Map<UUID, Integer> colors = null;
+        int distinct = 0;
+        while (true) {
+            final Map<UUID, String> signatures = new HashMap<>();
+            for (final NodeBox box : nodes) {
+                if (colors == null) {
+                    signatures.put(
+                        box.id(),
+                        box.width() + "x"
+                            + box.height()
+                            + ":"
+                            + box.inputPorts()
+                            + ":"
+                            + box.outputPorts()
+                            + ":"
+                            + nodeHeight.get(box.id())
+                            + ":"
+                            + names.get(box.id()));
+                } else {
+                    final List<String> entries = new ArrayList<>();
+                    for (final LinkEnd end : ends.get(box.id())) {
+                        entries.add(end.head() + colors.get(end.peer()));
+                    }
+                    Collections.sort(entries);
+                    signatures.put(box.id(), colors.get(box.id()) + "|" + String.join(",", entries));
+                }
+            }
+
+            // New colors are ranks in the sorted distinct signatures, so they depend only on
+            // signature content, never on node iteration order.
+            final List<String> sorted = new ArrayList<>(new TreeSet<>(signatures.values()));
+            final Map<String, Integer> rankOf = new HashMap<>();
+            for (int i = 0; i < sorted.size(); i++) {
+                rankOf.put(sorted.get(i), i);
+            }
+            final Map<UUID, Integer> next = new HashMap<>();
+            for (final Map.Entry<UUID, String> entry : signatures.entrySet()) {
+                next.put(entry.getKey(), rankOf.get(entry.getValue()));
+            }
+            if (colors != null && sorted.size() == distinct) {
+                return next;
+            }
+            distinct = sorted.size();
+            colors = next;
+        }
     }
 
     /** Iterative Tarjan; returns SCC index per node. */

--- a/src/main/java/com/sbancuz/plannh/layout/AutoLayout.java
+++ b/src/main/java/com/sbancuz/plannh/layout/AutoLayout.java
@@ -28,6 +28,8 @@ import org.eclipse.elk.graph.ElkNode;
 import org.eclipse.elk.graph.ElkPort;
 import org.eclipse.elk.graph.util.ElkGraphUtil;
 
+import com.sbancuz.plannh.gui.PortGeometry;
+
 /**
  * Deterministic layered auto-layout over the machine digraph.
  *
@@ -65,11 +67,6 @@ public final class AutoLayout {
     // sit clear of descending edges and port approaches stay straight.
     private static final double EDGE_CHANNEL_SPACING = 18.0;
     private static final double EDGE_NODE_SPACING = 24.0;
-
-    // Pin geometry mirrored from RecipeNodeWidget (same constants CanvasWidget duplicates):
-    // port i sits at y = (i + 1) * PORT_SPACING + PORT_ORIGIN on its node edge.
-    private static final int PORT_SPACING = 18;
-    private static final int PORT_ORIGIN = 10;
 
     static {
         // We invoke LayeredLayoutProvider directly instead of going through ELK's plugin/service
@@ -133,7 +130,7 @@ public final class AutoLayout {
                 final ElkPort p = ElkGraphUtil.createPort(n);
                 p.setProperty(CoreOptions.PORT_SIDE, PortSide.EAST);
                 p.setX(box.width());
-                p.setY((i + 1) * PORT_SPACING + PORT_ORIGIN);
+                p.setY(PortGeometry.portY(i));
                 outs[i] = p;
             }
             outPorts.put(box.id(), outs);
@@ -143,7 +140,7 @@ public final class AutoLayout {
                 final ElkPort p = ElkGraphUtil.createPort(n);
                 p.setProperty(CoreOptions.PORT_SIDE, PortSide.WEST);
                 p.setX(0);
-                p.setY((i + 1) * PORT_SPACING + PORT_ORIGIN);
+                p.setY(PortGeometry.portY(i));
                 ins[i] = p;
             }
             inPorts.put(box.id(), ins);

--- a/src/main/java/com/sbancuz/plannh/layout/AutoLayout.java
+++ b/src/main/java/com/sbancuz/plannh/layout/AutoLayout.java
@@ -20,6 +20,7 @@ import org.eclipse.elk.alg.layered.options.OrderingStrategy;
 import org.eclipse.elk.core.data.LayoutMetaDataService;
 import org.eclipse.elk.core.options.CoreOptions;
 import org.eclipse.elk.core.options.Direction;
+import org.eclipse.elk.core.options.EdgeRouting;
 import org.eclipse.elk.core.options.PortConstraints;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.BasicProgressMonitor;
@@ -54,8 +55,21 @@ public final class AutoLayout {
 
     /** Nodes above this count switch to the scalable placement strategy. */
     private static final int BIG_GRAPH_NODES = 300;
+    // Compact on purpose. The arrow router inflates nodes by a 12-unit margin per side, so
+    // layer spacing must stay above ~30 or the inter-layer corridors close entirely.
     private static final double LAYER_SPACING = 50.0;
     private static final double NODE_SPACING = 25.0;
+    // Per-edge channel width ELK reserves in a layer gap (the router uses 6-unit cells and
+    // keeps a cell of clearance between arrows, so ~2 cells per arrow), and the clearance
+    // between those channels and the nodes flanking the gap - generous so downstream nodes
+    // sit clear of descending edges and port approaches stay straight.
+    private static final double EDGE_CHANNEL_SPACING = 18.0;
+    private static final double EDGE_NODE_SPACING = 24.0;
+
+    // Pin geometry mirrored from RecipeNodeWidget (same constants CanvasWidget duplicates):
+    // port i sits at y = (i + 1) * PORT_SPACING + PORT_ORIGIN on its node edge.
+    private static final int PORT_SPACING = 18;
+    private static final int PORT_ORIGIN = 10;
 
     static {
         // We invoke LayeredLayoutProvider directly instead of going through ELK's plugin/service
@@ -80,6 +94,11 @@ public final class AutoLayout {
         root.setProperty(CoreOptions.RANDOM_SEED, 1);
         root.setProperty(CoreOptions.SPACING_NODE_NODE, NODE_SPACING);
         root.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, LAYER_SPACING);
+        // Orthogonal edge routing makes ELK reserve a channel per edge crossing each layer
+        // gap, so gaps widen with edge count instead of every corridor being LAYER_SPACING.
+        root.setProperty(CoreOptions.EDGE_ROUTING, EdgeRouting.ORTHOGONAL);
+        root.setProperty(LayeredOptions.SPACING_EDGE_EDGE_BETWEEN_LAYERS, EDGE_CHANNEL_SPACING);
+        root.setProperty(LayeredOptions.SPACING_EDGE_NODE_BETWEEN_LAYERS, EDGE_NODE_SPACING);
         root.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.LAYER_SWEEP);
         root.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.DEPTH_FIRST);
         root.setProperty(LayeredOptions.THOROUGHNESS, 30);
@@ -103,24 +122,28 @@ public final class AutoLayout {
             final ElkNode n = ElkGraphUtil.createNode(root);
             n.setWidth(box.width());
             n.setHeight(box.height());
-            n.setProperty(CoreOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_ORDER);
+            // Real pin coordinates, not just sides: node placement then straightens edges
+            // against the positions the canvas actually draws, so single connections line up
+            // horizontally instead of jogging by ELK's invented port spread.
+            n.setProperty(CoreOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_POS);
             elkNodes.put(box.id(), n);
 
-            // FIXED_ORDER expects ports listed clockwise from the top-left corner:
-            // east side top-to-bottom, then west side bottom-to-top. That matches how
-            // RecipeNodeWidget stacks ports vertically by index on each side.
             final ElkPort[] outs = new ElkPort[box.outputPorts()];
             for (int i = 0; i < box.outputPorts(); i++) {
                 final ElkPort p = ElkGraphUtil.createPort(n);
                 p.setProperty(CoreOptions.PORT_SIDE, PortSide.EAST);
+                p.setX(box.width());
+                p.setY((i + 1) * PORT_SPACING + PORT_ORIGIN);
                 outs[i] = p;
             }
             outPorts.put(box.id(), outs);
 
             final ElkPort[] ins = new ElkPort[box.inputPorts()];
-            for (int i = box.inputPorts() - 1; i >= 0; i--) {
+            for (int i = 0; i < box.inputPorts(); i++) {
                 final ElkPort p = ElkGraphUtil.createPort(n);
                 p.setProperty(CoreOptions.PORT_SIDE, PortSide.WEST);
+                p.setX(0);
+                p.setY((i + 1) * PORT_SPACING + PORT_ORIGIN);
                 ins[i] = p;
             }
             inPorts.put(box.id(), ins);

--- a/src/main/java/com/sbancuz/plannh/layout/AutoLayout.java
+++ b/src/main/java/com/sbancuz/plannh/layout/AutoLayout.java
@@ -34,7 +34,7 @@ import com.sbancuz.plannh.gui.PortGeometry;
  * Deterministic layered auto-layout over the machine digraph.
  *
  * <p>
- * Uses ELK layered with the option set tuned in the flowv2 research corpus: DEPTH_FIRST cycle
+ * Uses ELK layered with an option set tuned on real recipe charts: DEPTH_FIRST cycle
  * breaking (halves crossings on recycle-heavy charts vs the GREEDY default), NETWORK_SIMPLEX
  * layering, thoroughness 30 and post-compaction. NETWORK_SIMPLEX node placement blows up past a
  * few hundred nodes, so large graphs fall back to BRANDES_KOEPF.

--- a/src/main/java/com/sbancuz/plannh/layout/AutoLayout.java
+++ b/src/main/java/com/sbancuz/plannh/layout/AutoLayout.java
@@ -95,6 +95,29 @@ public final class AutoLayout {
 
     private AutoLayout() {}
 
+    /** Guards the one-time ELK warm-up. */
+    private static volatile boolean warmedUp;
+
+    /**
+     * Runs one tiny layout so ELK's class loading and metadata registration happen off the
+     * first real click. Safe to race with {@link #layout}: both run the same stateless static
+     * path, the flag only skips repeat warm-ups. Failures are ignored - the first real layout
+     * would surface them anyway.
+     */
+    public static void warmup() {
+        if (warmedUp) return;
+        record WarmupNode(UUID id, String machineName, int worldWidth, int worldHeight, int inputCount, int outputCount)
+            implements LayoutNode {}
+        try {
+            final UUID a = new UUID(0, 1);
+            final UUID b = new UUID(0, 2);
+            layout(
+                List.of(new WarmupNode(a, "a", 100, 80, 0, 1), new WarmupNode(b, "b", 100, 80, 1, 0)),
+                List.of(new Edge(new UUID(0, 3), a, b, 0, 0)));
+            warmedUp = true;
+        } catch (final Exception ignored) {}
+    }
+
     /**
      * Computes new world-space top-left positions for every node. Positions are relative to an
      * arbitrary origin; callers anchor the result wherever they want.

--- a/src/main/java/com/sbancuz/plannh/layout/AutoLayout.java
+++ b/src/main/java/com/sbancuz/plannh/layout/AutoLayout.java
@@ -1,0 +1,269 @@
+package com.sbancuz.plannh.layout;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.eclipse.elk.alg.layered.LayeredLayoutProvider;
+import org.eclipse.elk.alg.layered.options.CrossingMinimizationStrategy;
+import org.eclipse.elk.alg.layered.options.CycleBreakingStrategy;
+import org.eclipse.elk.alg.layered.options.GraphCompactionStrategy;
+import org.eclipse.elk.alg.layered.options.LayeredOptions;
+import org.eclipse.elk.alg.layered.options.LayeringStrategy;
+import org.eclipse.elk.alg.layered.options.NodePlacementStrategy;
+import org.eclipse.elk.alg.layered.options.OrderingStrategy;
+import org.eclipse.elk.core.data.LayoutMetaDataService;
+import org.eclipse.elk.core.options.CoreOptions;
+import org.eclipse.elk.core.options.Direction;
+import org.eclipse.elk.core.options.PortConstraints;
+import org.eclipse.elk.core.options.PortSide;
+import org.eclipse.elk.core.util.BasicProgressMonitor;
+import org.eclipse.elk.graph.ElkNode;
+import org.eclipse.elk.graph.ElkPort;
+import org.eclipse.elk.graph.util.ElkGraphUtil;
+
+/**
+ * Deterministic layered auto-layout over the machine digraph.
+ *
+ * <p>
+ * Uses ELK layered with the option set tuned in the flowv2 research corpus: DEPTH_FIRST cycle
+ * breaking (halves crossings on recycle-heavy charts vs the GREEDY default), NETWORK_SIMPLEX
+ * layering, thoroughness 30 and post-compaction. NETWORK_SIMPLEX node placement blows up past a
+ * few hundred nodes, so large graphs fall back to BRANDES_KOEPF.
+ *
+ * <p>
+ * Layered engines consume nodes in model order, so the same chart built in a different NEI click
+ * order would lay out differently. Nodes are therefore canonicalized first: SCC condensation
+ * height, then name, then id. Same graph, same layout, always.
+ *
+ * <p>
+ * This class is deliberately free of Minecraft/NEI imports so it can be exercised headlessly.
+ */
+public final class AutoLayout {
+
+    /** World-space size and port counts of one machine node. */
+    public record NodeBox(UUID id, String name, int width, int height, int inputPorts, int outputPorts) {}
+
+    /** One drawn edge: source node output port -> target node input port. */
+    public record Link(UUID source, int outputIndex, UUID target, int inputIndex) {}
+
+    /** Nodes above this count switch to the scalable placement strategy. */
+    private static final int BIG_GRAPH_NODES = 300;
+    private static final double LAYER_SPACING = 50.0;
+    private static final double NODE_SPACING = 25.0;
+
+    static {
+        // We invoke LayeredLayoutProvider directly instead of going through ELK's plugin/service
+        // machinery, so the property clone registry must be initialized by hand.
+        LayoutMetaDataService.initElkReflect();
+    }
+
+    private AutoLayout() {}
+
+    /**
+     * Computes new world-space top-left positions for every node. Positions are relative to an
+     * arbitrary origin; callers anchor the result wherever they want.
+     */
+    public static Map<UUID, int[]> layout(final List<NodeBox> nodes, final List<Link> links) {
+        final Map<UUID, int[]> result = new HashMap<>();
+        if (nodes.isEmpty()) return result;
+
+        final List<NodeBox> ordered = canonicalOrder(nodes, links);
+
+        final ElkNode root = ElkGraphUtil.createGraph();
+        root.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        root.setProperty(CoreOptions.RANDOM_SEED, 1);
+        root.setProperty(CoreOptions.SPACING_NODE_NODE, NODE_SPACING);
+        root.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, LAYER_SPACING);
+        root.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.LAYER_SWEEP);
+        root.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.DEPTH_FIRST);
+        root.setProperty(LayeredOptions.THOROUGHNESS, 30);
+        root.setProperty(LayeredOptions.LAYERING_STRATEGY, LayeringStrategy.NETWORK_SIMPLEX);
+        root.setProperty(
+            LayeredOptions.NODE_PLACEMENT_STRATEGY,
+            nodes.size() <= BIG_GRAPH_NODES ? NodePlacementStrategy.NETWORK_SIMPLEX
+                : NodePlacementStrategy.BRANDES_KOEPF);
+        root.setProperty(
+            LayeredOptions.COMPACTION_POST_COMPACTION_STRATEGY,
+            GraphCompactionStrategy.LEFT_RIGHT_CONSTRAINT_LOCKING);
+        if (nodes.size() > BIG_GRAPH_NODES) {
+            root.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.NODES_AND_EDGES);
+        }
+
+        final Map<UUID, ElkNode> elkNodes = new HashMap<>();
+        final Map<UUID, ElkPort[]> inPorts = new HashMap<>();
+        final Map<UUID, ElkPort[]> outPorts = new HashMap<>();
+
+        for (final NodeBox box : ordered) {
+            final ElkNode n = ElkGraphUtil.createNode(root);
+            n.setWidth(box.width());
+            n.setHeight(box.height());
+            n.setProperty(CoreOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_ORDER);
+            elkNodes.put(box.id(), n);
+
+            // FIXED_ORDER expects ports listed clockwise from the top-left corner:
+            // east side top-to-bottom, then west side bottom-to-top. That matches how
+            // RecipeNodeWidget stacks ports vertically by index on each side.
+            final ElkPort[] outs = new ElkPort[box.outputPorts()];
+            for (int i = 0; i < box.outputPorts(); i++) {
+                final ElkPort p = ElkGraphUtil.createPort(n);
+                p.setProperty(CoreOptions.PORT_SIDE, PortSide.EAST);
+                outs[i] = p;
+            }
+            outPorts.put(box.id(), outs);
+
+            final ElkPort[] ins = new ElkPort[box.inputPorts()];
+            for (int i = box.inputPorts() - 1; i >= 0; i--) {
+                final ElkPort p = ElkGraphUtil.createPort(n);
+                p.setProperty(CoreOptions.PORT_SIDE, PortSide.WEST);
+                ins[i] = p;
+            }
+            inPorts.put(box.id(), ins);
+        }
+
+        for (final Link link : links) {
+            final ElkPort[] outs = outPorts.get(link.source());
+            final ElkPort[] ins = inPorts.get(link.target());
+            if (outs == null || ins == null) continue;
+            if (link.outputIndex() < 0 || link.outputIndex() >= outs.length) continue;
+            if (link.inputIndex() < 0 || link.inputIndex() >= ins.length) continue;
+            ElkGraphUtil.createSimpleEdge(outs[link.outputIndex()], ins[link.inputIndex()]);
+        }
+
+        new LayeredLayoutProvider().layout(root, new BasicProgressMonitor());
+
+        for (final Map.Entry<UUID, ElkNode> entry : elkNodes.entrySet()) {
+            final ElkNode n = entry.getValue();
+            result.put(entry.getKey(), new int[] { (int) Math.round(n.getX()), (int) Math.round(n.getY()) });
+        }
+        return result;
+    }
+
+    /**
+     * Orders nodes by SCC-condensation height (sources first), then name, then id, so the layout
+     * is independent of the order recipes were added in NEI.
+     */
+    static List<NodeBox> canonicalOrder(final List<NodeBox> nodes, final List<Link> links) {
+        final Map<UUID, List<UUID>> adjacency = new HashMap<>();
+        for (final NodeBox box : nodes) adjacency.put(box.id(), new ArrayList<>());
+        for (final Link link : links) {
+            final List<UUID> next = adjacency.get(link.source());
+            if (next != null && adjacency.containsKey(link.target())) next.add(link.target());
+        }
+
+        final Map<UUID, Integer> sccOf = tarjanScc(adjacency);
+
+        // Condensation edges, then longest-path height per SCC from the source side.
+        final Map<Integer, List<Integer>> sccAdjacency = new HashMap<>();
+        final Map<Integer, Integer> inDegree = new HashMap<>();
+        for (final int scc : sccOf.values()) {
+            sccAdjacency.putIfAbsent(scc, new ArrayList<>());
+            inDegree.putIfAbsent(scc, 0);
+        }
+        for (final Link link : links) {
+            final Integer a = sccOf.get(link.source());
+            final Integer b = sccOf.get(link.target());
+            if (a == null || b == null || a.equals(b)) continue;
+            sccAdjacency.get(a)
+                .add(b);
+            inDegree.merge(b, 1, Integer::sum);
+        }
+
+        final Map<Integer, Integer> height = new HashMap<>();
+        final Deque<Integer> queue = new ArrayDeque<>();
+        for (final Map.Entry<Integer, Integer> entry : inDegree.entrySet()) {
+            if (entry.getValue() == 0) {
+                height.put(entry.getKey(), 0);
+                queue.add(entry.getKey());
+            }
+        }
+        final Map<Integer, Integer> remaining = new HashMap<>(inDegree);
+        while (!queue.isEmpty()) {
+            final int scc = queue.poll();
+            for (final int next : sccAdjacency.get(scc)) {
+                height.merge(next, height.get(scc) + 1, Math::max);
+                if (remaining.merge(next, -1, Integer::sum) == 0) {
+                    queue.add(next);
+                }
+            }
+        }
+
+        final List<NodeBox> ordered = new ArrayList<>(nodes);
+        ordered.sort(
+            Comparator.<NodeBox>comparingInt(box -> height.getOrDefault(sccOf.get(box.id()), 0))
+                .thenComparing(box -> box.name() == null ? "" : box.name())
+                .thenComparing(
+                    box -> box.id()
+                        .toString()));
+        return ordered;
+    }
+
+    /** Iterative Tarjan; returns SCC index per node. */
+    private static Map<UUID, Integer> tarjanScc(final Map<UUID, List<UUID>> adjacency) {
+        final Map<UUID, Integer> index = new HashMap<>();
+        final Map<UUID, Integer> lowLink = new HashMap<>();
+        final Map<UUID, Boolean> onStack = new HashMap<>();
+        final Deque<UUID> stack = new ArrayDeque<>();
+        final Map<UUID, Integer> sccOf = new HashMap<>();
+        final int[] counters = new int[2]; // next index, next scc id
+
+        for (final UUID start : adjacency.keySet()) {
+            if (index.containsKey(start)) continue;
+
+            // Explicit DFS stack: node + position in its adjacency list.
+            final Deque<UUID> dfs = new ArrayDeque<>();
+            final Deque<Integer> edgePos = new ArrayDeque<>();
+            dfs.push(start);
+            edgePos.push(0);
+            index.put(start, counters[0]);
+            lowLink.put(start, counters[0]);
+            counters[0]++;
+            stack.push(start);
+            onStack.put(start, true);
+
+            while (!dfs.isEmpty()) {
+                final UUID node = dfs.peek();
+                final int pos = edgePos.peek();
+                final List<UUID> next = adjacency.get(node);
+
+                if (pos < next.size()) {
+                    edgePos.push(edgePos.pop() + 1);
+                    final UUID target = next.get(pos);
+                    if (!index.containsKey(target)) {
+                        dfs.push(target);
+                        edgePos.push(0);
+                        index.put(target, counters[0]);
+                        lowLink.put(target, counters[0]);
+                        counters[0]++;
+                        stack.push(target);
+                        onStack.put(target, true);
+                    } else if (Boolean.TRUE.equals(onStack.get(target))) {
+                        lowLink.merge(node, index.get(target), Math::min);
+                    }
+                } else {
+                    dfs.pop();
+                    edgePos.pop();
+                    if (!dfs.isEmpty()) {
+                        lowLink.merge(dfs.peek(), lowLink.get(node), Math::min);
+                    }
+                    if (lowLink.get(node)
+                        .equals(index.get(node))) {
+                        UUID member;
+                        do {
+                            member = stack.pop();
+                            onStack.put(member, false);
+                            sccOf.put(member, counters[1]);
+                        } while (!member.equals(node));
+                        counters[1]++;
+                    }
+                }
+            }
+        }
+        return sccOf;
+    }
+}

--- a/src/main/java/com/sbancuz/plannh/layout/AutoLayout.java
+++ b/src/main/java/com/sbancuz/plannh/layout/AutoLayout.java
@@ -40,8 +40,8 @@ import com.sbancuz.plannh.gui.PortGeometry;
  * <p>
  * Uses ELK layered with an option set tuned on real recipe charts: DEPTH_FIRST cycle
  * breaking (halves crossings on recycle-heavy charts vs the GREEDY default), NETWORK_SIMPLEX
- * layering, thoroughness 30 and post-compaction. NETWORK_SIMPLEX node placement blows up past a
- * few hundred nodes, so large graphs fall back to BRANDES_KOEPF.
+ * layering, thoroughness 30 and post-compaction. NETWORK_SIMPLEX node placement costs grow
+ * explosively with edge density, so anything past a small chart falls back to BRANDES_KOEPF.
  *
  * <p>
  * Layered engines consume nodes in model order, so the same chart built in a different NEI click
@@ -74,8 +74,14 @@ public final class AutoLayout {
         int outputCount();
     }
 
-    /** Nodes above this count switch to the scalable placement strategy. */
+    /** Above this count ELK's model-order tie-breaking is enabled to keep big charts stable. */
     private static final int BIG_GRAPH_NODES = 300;
+    // NETWORK_SIMPLEX placement is worth its cost only on small charts. Measured on chain +
+    // 65% random cross links, 4 ports per node: 60 nodes/97 edges 0.4s, 80/130 1.0s, 100/163
+    // 4.6s, 150/245 34s, and 200/327 dies in ELK's recursive NGraph.dfs with a StackOverflowError.
+    // BRANDES_KOEPF is flat over the same range (0.2s at 60, 0.6s at 150, 3.5s at 320).
+    private static final int NS_MAX_NODES = 60;
+    private static final int NS_MAX_EDGES = 120;
     // Compact on purpose. The arrow router inflates nodes by a 12-unit margin per side, so
     // layer spacing must stay above ~30 or the inter-layer corridors close entirely.
     private static final double LAYER_SPACING = 50.0;
@@ -158,7 +164,7 @@ public final class AutoLayout {
         root.setProperty(LayeredOptions.LAYERING_STRATEGY, LayeringStrategy.NETWORK_SIMPLEX);
         root.setProperty(
             LayeredOptions.NODE_PLACEMENT_STRATEGY,
-            nodes.size() <= BIG_GRAPH_NODES ? NodePlacementStrategy.NETWORK_SIMPLEX
+            nodes.size() <= NS_MAX_NODES && links.size() <= NS_MAX_EDGES ? NodePlacementStrategy.NETWORK_SIMPLEX
                 : NodePlacementStrategy.BRANDES_KOEPF);
         root.setProperty(
             LayeredOptions.COMPACTION_POST_COMPACTION_STRATEGY,

--- a/src/main/java/com/sbancuz/plannh/layout/AutoLayout.java
+++ b/src/main/java/com/sbancuz/plannh/layout/AutoLayout.java
@@ -96,13 +96,11 @@ public final class AutoLayout {
     private AutoLayout() {}
 
     /** Guards the one-time ELK warm-up. */
-    private static volatile boolean warmedUp;
+    private static boolean warmedUp;
 
     /**
      * Runs one tiny layout so ELK's class loading and metadata registration happen off the
-     * first real click. Safe to race with {@link #layout}: both run the same stateless static
-     * path, the flag only skips repeat warm-ups. Failures are ignored - the first real layout
-     * would surface them anyway.
+     * first real click. Failures are ignored - the first real layout would surface them anyway.
      */
     public static void warmup() {
         if (warmedUp) return;

--- a/src/main/java/com/sbancuz/plannh/layout/AutoLayout.java
+++ b/src/main/java/com/sbancuz/plannh/layout/AutoLayout.java
@@ -127,6 +127,21 @@ public final class AutoLayout {
      * arbitrary origin; callers anchor the result wherever they want.
      */
     public static Map<UUID, int[]> layout(final Collection<? extends LayoutNode> nodes, final Collection<Edge> links) {
+        try {
+            return layout(nodes, links, GraphCompactionStrategy.LEFT_RIGHT_CONSTRAINT_LOCKING);
+        } catch (final IllegalStateException e) {
+            // "Invalid hitboxes for scanline constraint calculation" - ELK's post-compaction pass
+            // rejects its own hitboxes on roughly 1 chart in 400 (measured: 3 of 1200 random
+            // charts, 18-40 nodes). It is a property of the chart, not a race, so an affected
+            // chart fails every time and this fallback is as deterministic as the primary path.
+            // Dropping the pass costs 3-20% width and no height. A second failure would be a
+            // different bug, so the retry runs unguarded.
+            return layout(nodes, links, GraphCompactionStrategy.NONE);
+        }
+    }
+
+    private static Map<UUID, int[]> layout(final Collection<? extends LayoutNode> nodes, final Collection<Edge> links,
+        final GraphCompactionStrategy compaction) {
         final Map<UUID, int[]> result = new HashMap<>();
         if (nodes.isEmpty()) return result;
 
@@ -166,9 +181,7 @@ public final class AutoLayout {
             LayeredOptions.NODE_PLACEMENT_STRATEGY,
             nodes.size() <= NS_MAX_NODES && links.size() <= NS_MAX_EDGES ? NodePlacementStrategy.NETWORK_SIMPLEX
                 : NodePlacementStrategy.BRANDES_KOEPF);
-        root.setProperty(
-            LayeredOptions.COMPACTION_POST_COMPACTION_STRATEGY,
-            GraphCompactionStrategy.LEFT_RIGHT_CONSTRAINT_LOCKING);
+        root.setProperty(LayeredOptions.COMPACTION_POST_COMPACTION_STRATEGY, compaction);
         if (nodes.size() > BIG_GRAPH_NODES) {
             root.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.NODES_AND_EDGES);
         }


### PR DESCRIPTION
## Functionality
- Adds auto-layout button, which uses SCC condensation height + ELK layout engine (new dependency)
- Add shift-click functionality to restore old chart if AL button was accidentally pressed
- Various improvements to ArrowRouter (never route under a machine node if there is an alternative option, clean up some pathological behavior, minimize bends)
- As a pre-emptive performance guard, graphs with >300 nodes use `BRANDES_KOEPF` instead of `NETWORK_SIMPLEX`. This I learned from trying to render nanocircuits in my flowv2 test repo. You lose some planarity, but it finishes in a reasonable amount of time
- For seamless user experience, warm up ELK in `ClientProxy.init` before first auto-layout

## Dev QOL
- Generalize port coordinate stuff into PortGeometry

## Downsides
- Adding ELK dependency adds 7MB to the publish jar. I cut down 1MB from it by dumping some unlikely to ever be used paths (docs, XML export), but there's only so much that can be done here. We will almost certainly use ELK in the long term (unless I figure out how to get OGDF working), so it's a good addition
- Changes more UI code, specifically `ArrowRouter`, making the inevitable MUI rework merge problem bigger (sorry)

## Licensing
| Library | Version | License |
|---|---|---|
| [Eclipse Layout Kernel (ELK)](https://github.com/eclipse-elk/elk) | 0.8.1 | [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/) |
| [Eclipse Modeling Framework (EMF)](https://projects.eclipse.org/projects/modeling.emf.emf) - `common`, `ecore` | 2.12.0 | [EPL-1.0](https://www.eclipse.org/legal/epl-v10.html) |
| [Guava](https://github.com/google/guava) | 30.1-jre | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) |

## Jar Size Impacts
| Component | Uncompressed | Share | Outcome |
|---|---:|---:|---|
| guava (+annotations) | 7.77MB | 43% | pinned 33.6 → 30.1-jre (ELK declares the open range `[15.0,)`) |
| EMF (`ecore` 3.4 + `common` 0.75) | 4.14MB | 23% | kept; `ecore.xmi` (0.52MB) excluded — unused, graphs are built programmatically |
| ELK (`alg` 2.9, `core` 0.72, `graph` 0.22) | 3.86MB | 21% | kept — the actual layout engine |
| ELK's documentation images | 1.14MB | 6% | excluded (docs-site PNG/SVG illustrations) |
| `model/` ecore/xsd metamodels | 0.23MB | 1% | excluded (design-time EMF files) |
| `META-INF/versions` | 0.37MB | 2% | shrinks with the guava pin |
| PlanNH itself | ~0.6MB | 3% | |

## Demo Video

https://github.com/user-attachments/assets/c34446b4-23f9-465c-85cf-603db18fcd26

## Technical Explanation

(ai generated)

The sort is doing two jobs: making the layout **deterministic** (a function of the graph, not of the order recipes were clicked in NEI), and feeding ELK a **flow-aligned traversal order** so its cycle breaker cuts recycle loops in the right place.

### 1. ELK is only deterministic *given* a node order

<details>
<summary>Click to expand</summary>

We pin `RANDOM_SEED`, so ELK itself has no randomness left — but several of its phases consume nodes in **model order** (the order they were added to the `ElkNode`), and break ties by it. Without the sort, model order = NEI click order.

The clearest case is the cycle breaker we use (`CycleBreakingStrategy.DEPTH_FIRST`). From ELK 0.8.1's [`DepthFirstCycleBreaker`](https://github.com/eclipse-elk/elk/blob/master/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/DepthFirstCycleBreaker.java):

```java
for (LNode node : nodes) {                  // <- model order
    if (Iterables.isEmpty(node.getIncomingEdges())) {
        sources.add(node);
    }
}
for (LNode source : sources) {
    dfs(source);
}
// Start more DFS runs for all nodes that have not been visited yet.
// These must be part of a cycle since they are not source nodes
for (int i = 0; i < nodeCount; i++) {       // <- model order again
    if (!visited[i]) {
        dfs(nodes.get(i));
    }
}
```

Any edge the DFS finds pointing back into its current path gets reversed for layering. So for a **source-less loop** (very common here — self-sustaining recycle chains where every machine has an input), *which node happens to come first in model order is the DFS entry point, and that decides which edge gets reversed, which decides the entire left-to-right layering downstream.*

Concretely, take a loop `Electrolyzer → Reactor → Centrifuge → Electrolyzer` with a tap `Centrifuge → Chem Bath`. Every node has an incoming edge, so there are no sources and the DFS entry is pure model order:

```mermaid
flowchart LR
  subgraph A ["User clicked Reactor first → chart reads Reactor → Centrifuge → Electrolyzer"]
    R1[Reactor] --> C1[Centrifuge] --> E1[Electrolyzer]
    E1 -. reversed .-> R1
    C1 --> O1[Chem Bath]
  end
```

```mermaid
flowchart LR
  subgraph B ["User clicked Electrolyzer first → chart reads Electrolyzer → Reactor → Centrifuge"]
    E2[Electrolyzer] --> R2[Reactor] --> C2[Centrifuge]
    C2 -. reversed .-> E2
    C2 --> O2[Chem Bath]
  end
```

Same graph, two click histories, two different pictures. Worse: model order is just insertion order, so deleting and re-adding an unrelated node can reshuffle the whole chart on the next auto-layout. With the canonical sort, auto-layout is idempotent and identical for everyone who builds the same chart.

</details>

### 2. Why not something simpler, like sorting by UUID?

That would already make layout deterministic *for one saved chart* — but node UUIDs are random at creation, so the same logical chart rebuilt from scratch would sort differently and lay out differently. And it does nothing for the quality issue below. So the sort key has to come from the *structure* of the graph plus stable machine names; the id is only the last-resort tiebreak between identical machines at identical depth.

### 3. Why SCC-condensation height specifically

<details>
<summary>Click to expand</summary>

The order we actually want is "upstream machines first" — topological order. Then:

- ELK's DFS starts at true sources and walks *with* the flow, so the only edges it reverses are genuine recycle edges (instead of reversing a main-flow edge because the DFS happened to enter a loop from the side);
- on big graphs (>300 nodes) where we enable `CONSIDER_MODEL_ORDER`, ELK's model-order tie-breaking in layering/crossing minimization agrees with flow direction instead of click history;
- height 0 first = sources leftmost, matching `Direction.RIGHT`.

But a topological order doesn't exist for cyclic graphs, and recycle loops are the norm in recipe charts. The standard fix ([cp-algorithms has a good writeup](https://cp-algorithms.com/graph/strongly-connected-components.html)) is to contract each **strongly connected component** into one super-node. The resulting *condensation* is guaranteed to be a DAG, so it *can* be ordered — we take longest-path height from the sources:

```mermaid
flowchart LR
  subgraph S0 ["SCC 0 · height 0"]
    M[Miner]
  end
  subgraph S1 ["SCC 1 · height 1 — recycle loop"]
    Ma[Macerator] --> W[Ore Washer] --> Ce[Centrifuge] --> Ma
  end
  subgraph S2 ["SCC 2 · height 2"]
    EBF[Blast Furnace]
  end
  subgraph S3 ["SCC 3 · height 3"]
    As[Assembler]
  end
  M --> Ma
  Ce --> EBF
  EBF --> As
  style S0 fill:#d8f5d0,color:#000
  style S1 fill:#fbd2d2,color:#000
  style S2 fill:#fdf3c0,color:#000
  style S3 fill:#d3dcfb,color:#000
```

condenses to:

```mermaid
flowchart LR
  A0["{Miner}<br/>h = 0"] --> A1["{Macerator, Ore Washer, Centrifuge}<br/>h = 1"] --> A2["{Blast Furnace}<br/>h = 2"] --> A3["{Assembler}<br/>h = 3"]
  style A0 fill:#d8f5d0,color:#000
  style A1 fill:#fbd2d2,color:#000
  style A2 fill:#fdf3c0,color:#000
  style A3 fill:#d3dcfb,color:#000
```

Sort key is `(SCC height, name, id)`. All members of a loop share one height, so within a loop the order falls through to the name — which is exactly what makes the DFS entry point into each loop (case 1 above) deterministic too: it's always the alphabetically first machine in the loop, not whichever one was clicked first.

Tarjan is just the linear-time way to get the SCCs; it's written iteratively because recursion depth would be the chart's path length.

One more addition to avoid layout shifts. Now graph coloring is used to guarantee a unique solution based on graph metadata (neighbors etc). Also edges follow a canonical order as well.

</details>

### 4. Update: closing the last gap — the id tiebreak

<details>
<summary>Click to expand</summary>

Section 3 left one honest hole: the final id tiebreak. Ids are random at creation, so two machines tying on `(height, name)` still ordered randomly — the same logical chart rebuilt from scratch could swap them. The commit closes this with **wiring colors**: an iterated graph-coloring pass (color refinement) that identifies each node by its surroundings instead of its random id.

**Where the id used to leak through.** One Miner output feeds two Chemical Reactors (same machine, same size), one line continuing to a Blast Furnace, the other to a Distillery. Both reactors tie on `(height, name)`, and because both edges leave the *same output port*, both vertical stackings have equal edge crossings — a genuine tie that only model order breaks. So whichever reactor happened to draw the smaller id decided the picture; in a headless harness that rebuilds the chart with fresh random ids and shuffled insertion order, 17 of 39 rebuilds flipped it:

```mermaid
flowchart LR
  subgraph A ["Rebuild 1 — EBF branch happens to sort first"]
    M1[Miner] --> RA1[Chemical Reactor] --> E1[Blast Furnace]
    M1 --> RB1[Chemical Reactor] --> S1[Distillery]
  end
```

```mermaid
flowchart LR
  subgraph B ["Rebuild 2 — Distillery branch happens to sort first"]
    M2[Miner] --> RB2[Chemical Reactor] --> S2[Distillery]
    M2 --> RA2[Chemical Reactor] --> E2[Blast Furnace]
  end
```

**Links leak the same way.** Holding the nodes, the ids and the node order all fixed and shuffling *only* the order links were drawn in still flips the branches on 19 of 39 rebuilds — node positions, not just edge routes: with equal crossings and fixed ports, ELK keeps whichever order it encounters first, and encounter order follows the edge list. So links are also sorted to follow the node canonicalization — `(source position, output port, target position, input port)` — which keeps edge routing stable for free.

**The coloring.** To pin the node order down, every node gets a canonical color. Take a harder version of the chart above, where the twin branches stay identical for one more hop before diverging.

Round 0 — color nodes by what they *are*: `(size, port counts, height, name)`. All four Chemical Reactors are indistinguishable and share a color:

```mermaid
flowchart LR
  M0[Miner] --> A0[Chemical Reactor] --> CA0[Chemical Reactor] --> E0[Blast Furnace]
  M0 --> B0[Chemical Reactor] --> CB0[Chemical Reactor] --> S0[Distillery]
  style M0 fill:#d8f5d0,color:#000
  style A0 fill:#fbd2d2,color:#000
  style B0 fill:#fbd2d2,color:#000
  style CA0 fill:#fbd2d2,color:#000
  style CB0 fill:#fbd2d2,color:#000
  style E0 fill:#d3dcfb,color:#000
  style S0 fill:#fdf3c0,color:#000
```

Round 1 — recolor every node by its own color plus the sorted list of `(own port, direction, peer color)`. The two middle reactors split, because one's output peer is a Blast Furnace and the other's is a Distillery. The two left reactors still tie: both see a green Miner upstream and a red reactor downstream:

```mermaid
flowchart LR
  M3[Miner] --> A3[Chemical Reactor] --> CA3[Chemical Reactor] --> E3[Blast Furnace]
  M3 --> B3[Chemical Reactor] --> CB3[Chemical Reactor] --> S3[Distillery]
  style M3 fill:#d8f5d0,color:#000
  style A3 fill:#fbd2d2,color:#000
  style B3 fill:#fbd2d2,color:#000
  style CA3 fill:#e8d5f5,color:#000
  style CB3 fill:#fde3c8,color:#000
  style E3 fill:#d3dcfb,color:#000
  style S3 fill:#fdf3c0,color:#000
```

Round 2 — recolor again, now with the round-1 colors. The left reactors split too, because their downstream peers no longer match:

```mermaid
flowchart LR
  M4[Miner] --> A4[Chemical Reactor] --> CA4[Chemical Reactor] --> E4[Blast Furnace]
  M4 --> B4[Chemical Reactor] --> CB4[Chemical Reactor] --> S4[Distillery]
  style M4 fill:#d8f5d0,color:#000
  style A4 fill:#cdeef0,color:#000
  style B4 fill:#f5c6dc,color:#000
  style CA4 fill:#e8d5f5,color:#000
  style CB4 fill:#fde3c8,color:#000
  style E4 fill:#d3dcfb,color:#000
  style S4 fill:#fdf3c0,color:#000
```

Every node now has its own color, so one more round changes nothing and the refinement stops. In general, a difference k hops away separates twins after k rounds — which is why the pass iterates at all: a single round would have stopped after the middle diagram, left the two red reactors tied on the random id, and the harness shows exactly that chart flipping on 19 of 39 rebuilds.

Two details that make the colors canonical: within a round, each new color is the *rank of the node's signature in the sorted list of distinct signatures*, so colors depend only on the graph, never on iteration order; and the signature includes port indices, so "feeds input 0" and "feeds input 1" of the same peer are different wirings.

The sort key becomes `(height, name, color, id)`. After this change, the id correctly orders all but true structural twins — and with iteration, "twin" now means *no chain of links anywhere in the chart distinguishes the two nodes*, so swapping them is invisible on screen.

**Cost.** Each round builds signatures in O(V + E) and ranks them with one sort; every round before the fixpoint must split at least one color class, so rounds ≤ V, bounding the worst case by O(V·(V+E)·log V). In practice rounds = distance to the nearest distinguishing feature, 2–4 on real charts. As a deliberately adversarial measurement: a 500-node chain of identically named machines (forces exactly one hop of progress per round, ~500 rounds) runs the whole `layout()` call, ELK included, in ~310 ms.

**Results.** Three harness scenarios — same-port fan-out, disconnected same-name components, and the two-hop twins above — each rebuilt 40 times with fresh random ids and shuffled node/link insertion: all coordinate-identical. The existing reference charts lay out unchanged.

</details>