### PR TITLE
Small QOL fixes

### DIFF
--- a/src/main/java/com/sbancuz/plannh/data/provider/gregtech/GTProvider.java
+++ b/src/main/java/com/sbancuz/plannh/data/provider/gregtech/GTProvider.java
@@ -275,8 +275,9 @@ public class GTProvider implements PropertyProvider {
         node.inputs.clear();
         node.outputs.clear();
 
+        // GT recipe arrays may contain null slots (e.g. gap outputs); skip them.
         for (int i = 0; i < r.mInputs.length; i++) {
-            if (r.mInputs[i].stackSize <= 0) continue;
+            if (r.mInputs[i] == null || r.mInputs[i].stackSize <= 0) continue;
             node.inputs.add(
                 new Port<>(
                     RecipePropertyAPI.ITEM,
@@ -284,6 +285,7 @@ public class GTProvider implements PropertyProvider {
                     r.mInputChances != null ? r.mInputChances[i] / 100.0f : 1.f));
         }
         for (int i = 0; i < r.mOutputs.length; i++) {
+            if (r.mOutputs[i] == null) continue;
             node.outputs.add(
                 new Port<>(
                     RecipePropertyAPI.ITEM,
@@ -291,7 +293,7 @@ public class GTProvider implements PropertyProvider {
                     r.mOutputChances != null ? r.mOutputChances[i] / 100.0f : 1.f));
         }
         for (int i = 0; i < r.mFluidInputs.length; i++) {
-            if (r.mFluidInputs[i].amount <= 0) continue;
+            if (r.mFluidInputs[i] == null || r.mFluidInputs[i].amount <= 0) continue;
             node.inputs.add(
                 new Port<>(
                     RecipePropertyAPI.FLUID,
@@ -299,6 +301,7 @@ public class GTProvider implements PropertyProvider {
                     r.mFluidInputChances != null ? r.mFluidInputChances[i] / 100.0f : 1.f));
         }
         for (int i = 0; i < r.mFluidOutputs.length; i++) {
+            if (r.mFluidOutputs[i] == null) continue;
             node.outputs.add(
                 new Port<>(
                     RecipePropertyAPI.FLUID,

--- a/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
+++ b/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
@@ -173,8 +173,8 @@ public class FlowchartScreen extends ModularScreen {
                                 }))
                         .child(
                             new CycleButton<>(BalanceMode.class).overlay(v -> IKey.str(CycleButton.shortName(v)))
-                                .current(
-                                    canvas.getGraph()
+                                .source(
+                                    () -> canvas.getGraph()
                                         .getBalanceMode())
                                 .onCycle(next -> {
                                     canvas.getGraph()

--- a/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
+++ b/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
@@ -125,7 +125,10 @@ public class FlowchartScreen extends ModularScreen {
         mainColumn.child(
             Flow.row()
                 .mainAxisAlignment(Alignment.MainAxis.SPACE_BETWEEN)
-                .height(16)
+                // MUI2's default widget height is 18: a 16-tall row makes the coverChildren
+                // button rows overflow the cross axis, and SimpleFlow then logs a padding
+                // warning for each of them on EVERY relayout (the log-spam bug).
+                .height(18)
                 .fullWidth()
                 .child(
                     Flow.row()

--- a/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
@@ -108,6 +108,8 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
     private static final int SETTING_BTN_W = 22;
     private static final int SETTING_INC_X = SETTING_DEC_X + SETTING_BTN_W;
     private static final int EXTRACTOR_BTN_W = 100;
+    private static final int HOLD_REPEAT_DELAY_MS = 350;
+    private static final int HOLD_REPEAT_INTERVAL_MS = 50;
 
     private static final DrawableResource BG_TEXTURE = new DrawableBuilder(
         "nei:textures/gui/recipebg.png",
@@ -141,7 +143,15 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
     private int hoverMx = -10000;
     private int hoverMy = -10000;
 
-    private record ClickZone(int ux1, int uy1, int ux2, int uy2, Runnable action) {
+    private boolean zoneHeld = false;
+    private int heldZoneMx, heldZoneMy;
+    private long zoneHoldStart, zoneLastRepeat;
+
+    private record ClickZone(int ux1, int uy1, int ux2, int uy2, Runnable action, boolean repeat) {
+
+        ClickZone(final int ux1, final int uy1, final int ux2, final int uy2, final Runnable action) {
+            this(ux1, uy1, ux2, uy2, action, false);
+        }
 
         boolean contains(final int ux, final int uy) {
             return ux >= ux1 && ux < ux2 && uy >= uy1 && uy < uy2;
@@ -296,6 +306,7 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
             neiWidget.draw(hoverMx, hoverMy);
             drawThroughputInfo();
             drawConfigContent();
+            repeatHeldZone();
             drawCloseButtonPixel(getArea().width, getArea().height);
             drawPorts();
             drawGroupMembershipBar();
@@ -541,6 +552,13 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
                     for (final ClickZone zone : configZones) {
                         if (zone.contains(mx, my)) {
                             zone.action.run();
+                            if (zone.repeat()) {
+                                zoneHeld = true;
+                                heldZoneMx = mx;
+                                heldZoneMy = my;
+                                zoneHoldStart = System.currentTimeMillis();
+                                zoneLastRepeat = zoneHoldStart;
+                            }
                             return Result.SUCCESS;
                         }
                     }
@@ -567,6 +585,7 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
     @Override
     public boolean onMouseRelease(final int mouseButton) {
         if (mouseButton == 0) {
+            zoneHeld = false;
             if (doubleClickPending) {
                 doubleClickPending = false;
                 openNeiRecipe();
@@ -671,6 +690,23 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
         }
     }
 
+    /**
+     * Re-fires the held [-]/[+] zone. Zones are rebuilt every frame, so re-hit-testing the
+     * press point picks up the closure holding the current value.
+     */
+    private void repeatHeldZone() {
+        if (!zoneHeld || !configOpen) return;
+        final long now = System.currentTimeMillis();
+        if (now - zoneHoldStart < HOLD_REPEAT_DELAY_MS || now - zoneLastRepeat < HOLD_REPEAT_INTERVAL_MS) return;
+        for (final ClickZone zone : configZones) {
+            if (zone.repeat() && zone.contains(heldZoneMx, heldZoneMy)) {
+                zone.action.run();
+                zoneLastRepeat = now;
+                return;
+            }
+        }
+    }
+
     private int drawSetting(final int x, final int y, final SettingDef<?> def, final MachineConfig c) {
         if (def.type == Integer.class) {
             return drawConfigIntField(x, y, def.label, c.getInt(def.key), def.minInt, def.maxInt, v -> {
@@ -707,12 +743,12 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
                 final int cur = def.options.indexOf(c.getString(def.key));
                 c.setString(def.key, def.options.get(Math.max(0, (Math.max(cur, 0)) - 1)));
                 onConfigChanged();
-            }));
+            }, true));
             configZones.add(new ClickZone(incX, y, incX + SETTING_BTN_W, y + CLICK_H, () -> {
                 final int cur = def.options.indexOf(c.getString(def.key));
                 c.setString(def.key, def.options.get(Math.min(def.options.size() - 1, (Math.max(cur, 0)) + 1)));
                 onConfigChanged();
-            }));
+            }, true));
             return y + LINE_H;
         }
         return y + LINE_H;
@@ -740,14 +776,16 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget> implements Intera
                 y,
                 x + SETTING_INC_X,
                 y + CLICK_H,
-                () -> { if (value > min) setter.accept(value - 1); }));
+                () -> { if (value > min) setter.accept(value - 1); },
+                true));
         configZones.add(
             new ClickZone(
                 x + SETTING_INC_X,
                 y,
                 x + SETTING_INC_X + SETTING_BTN_W,
                 y + CLICK_H,
-                () -> { if (value < max) setter.accept(value + 1); }));
+                () -> { if (value < max) setter.accept(value + 1); },
+                true));
         return y + LINE_H;
     }
 

--- a/src/main/java/com/sbancuz/plannh/gui/components/CycleButton.java
+++ b/src/main/java/com/sbancuz/plannh/gui/components/CycleButton.java
@@ -2,6 +2,7 @@ package com.sbancuz.plannh.gui.components;
 
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -17,6 +18,8 @@ public class CycleButton<E extends Enum<E>> extends ButtonWidget<CycleButton<E>>
     private Function<E, IKey> overlayFn;
     @Nullable
     private Consumer<E> onCycle;
+    @Nullable
+    private Supplier<E> source;
 
     public CycleButton(final Class<E> enumClass) {
         this.values = enumClass.getEnumConstants();
@@ -40,10 +43,22 @@ public class CycleButton<E extends Enum<E>> extends ButtonWidget<CycleButton<E>>
         return this;
     }
 
+    /**
+     * Live value getter: the overlay follows it and cycling starts from it, so the button
+     * can't desync when the value changes elsewhere (e.g. a graph swap).
+     */
+    public CycleButton<E> source(final Supplier<E> source) {
+        this.source = source;
+        if (overlayFn != null) {
+            overlay(IKey.dynamicKey(() -> overlayFn.apply(source.get())));
+        }
+        return this;
+    }
+
     public E cycle(final E old) {
         final int nextOrdinal = (old.ordinal() + 1) % values.length;
         current = values[nextOrdinal];
-        if (overlayFn != null) {
+        if (overlayFn != null && source == null) {
             overlay(overlayFn.apply(current));
         }
         return current;
@@ -57,7 +72,7 @@ public class CycleButton<E extends Enum<E>> extends ButtonWidget<CycleButton<E>>
     @Override
     public @NotNull Result onMousePressed(final int mouseButton) {
         if (onCycle == null) return Result.IGNORE;
-        final E next = cycle(current);
+        final E next = cycle(source != null ? source.get() : current);
         onCycle.accept(next);
         return Result.SUCCESS;
     }


### PR DESCRIPTION
1. Patch MUI logspam: `Widget Row is larger with padding on axis Y than parent Row. Padding can't be applied correctly!` (NOTE: this is currently duplicated in auto-layout, I will remove it soon to avoid merge conflict)
2. Add a repeat functionality if the -/+ button is held down in the config window. This is handly for making integer throughputs for factory chart demos
3. Fix an edge case where the buttons could desync with the canvas state. I noticed this when deleting a chart slot in Auto mode (a new addition from my factory solver branch) - it would keep the button in AUT, but it would silently switch to OUT under the hood (which was visible in the summary node).
4. Not sure if this actually happens in normal practice, but I had the game crash with GT recipe nulls when I was importing platline's gtnh-flow YAML chart. (This may be when it was trying to import non-supported machine types.) This PR adds a defensive handling of GT recipe input/outputs being null.