### PR TITLE
Summary and Solver QOL

### DIFF
--- a/src/main/java/com/sbancuz/plannh/Config.java
+++ b/src/main/java/com/sbancuz/plannh/Config.java
@@ -1,6 +1,9 @@
 package com.sbancuz.plannh;
 
 import java.io.File;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
 
 import net.minecraftforge.common.config.Configuration;
 
@@ -8,6 +11,46 @@ public final class Config {
 
     /** Dev diagnostic: log a headless repro of every arrow-routing recompute. */
     public static boolean debugRouteDump = false;
+
+    /**
+     * Drops the summary's Machine Counts section entirely rather than folding it. Separate from the
+     * fold state because they answer different questions: a fold is "not right now" and lives per
+     * save, this is "never show me this" and lives with the install.
+     */
+    public static boolean hideMachineCountsSection = false;
+
+    /**
+     * Ingredients nobody plumbs. The wiring diagnostics exist to catch an edge the user meant to
+     * draw, and a chart taking water from outside while another machine happens to make some is
+     * not that - it is how everyone builds. Names, not registry ids: this is a nuisance filter the
+     * user edits by hand, and the panel already talks to them in display names.
+     */
+    public static final String[] DEFAULT_FREE_INGREDIENTS = { "Water" };
+
+    /** {@link #DEFAULT_FREE_INGREDIENTS} folded to lower case for lookup. */
+    private static Set<String> freeIngredients = lowercased(DEFAULT_FREE_INGREDIENTS);
+
+    /** Whether wiring diagnostics should stay quiet about this ingredient. */
+    public static boolean isFreeIngredient(final String displayName) {
+        return freeIngredients.contains(
+            displayName.trim()
+                .toLowerCase(Locale.ROOT));
+    }
+
+    /** Replaces the free list. Names are matched case- and whitespace-insensitively from here on. */
+    public static void setFreeIngredients(final String... names) {
+        freeIngredients = lowercased(names);
+    }
+
+    private static Set<String> lowercased(final String[] names) {
+        final Set<String> set = new HashSet<>();
+        for (final String name : names) {
+            set.add(
+                name.trim()
+                    .toLowerCase(Locale.ROOT));
+        }
+        return set;
+    }
 
     /**
      * How long the balancer is allowed to look for a better answer, as a percentage of the tuned
@@ -42,6 +85,25 @@ public final class Config {
             "debug",
             false,
             "Log a replayable dump of the arrow-routing input on every route recompute");
+
+        hideMachineCountsSection = configuration.getBoolean(
+            "hideMachineCountsSection",
+            "gui",
+            false,
+            "Leave the Machine Counts section (per-machine operation counts, and the ops/cycle"
+                + " totals) out of the summary panel altogether, instead of folding it away");
+
+        setFreeIngredients(
+            configuration
+                .get(
+                    "solver",
+                    "freeIngredients",
+                    DEFAULT_FREE_INGREDIENTS,
+                    "Ingredients the solver never suggests wiring up. Display names, case"
+                        + " insensitive. Anything effectively free in the pack belongs here:"
+                        + " otherwise every chart that takes water from outside reports a missing"
+                        + " edge to whatever else happens to produce it.")
+                .getStringList());
 
         solverEffortPercent = configuration.getInt(
             "solverEffortPercent",

--- a/src/main/java/com/sbancuz/plannh/Config.java
+++ b/src/main/java/com/sbancuz/plannh/Config.java
@@ -13,19 +13,16 @@ public final class Config {
     public static boolean debugRouteDump = false;
 
     /**
-     * Drops the summary's Machine Counts section entirely rather than folding it. Separate from the
-     * fold state because they answer different questions: a fold is "not right now" and lives per
-     * save, this is "never show me this" and lives with the install.
+     * Drops the summary's Machine Counts section entirely rather than folding it: a fold is "not on
+     * this chart" and lives per slot, this is "never" and lives with the install.
      */
     public static boolean hideMachineCountsSection = false;
 
     /**
-     * Ingredients nobody plumbs. The wiring diagnostics exist to catch an edge the user meant to
-     * draw, and a chart taking water from outside while another machine happens to make some is
-     * not that - it is how everyone builds. Names, not registry ids: this is a nuisance filter the
-     * user edits by hand, and the panel already talks to them in display names.
+     * Ingredients nobody plumbs, so the wiring diagnostics stay quiet about them. Display names
+     * rather than registry ids: this is a nuisance filter the user edits by hand.
      */
-    public static final String[] DEFAULT_FREE_INGREDIENTS = { "Water" };
+    private static final String[] DEFAULT_FREE_INGREDIENTS = { "Water" };
 
     /** {@link #DEFAULT_FREE_INGREDIENTS} folded to lower case for lookup. */
     private static Set<String> freeIngredients = lowercased(DEFAULT_FREE_INGREDIENTS);
@@ -40,6 +37,10 @@ public final class Config {
     /** Replaces the free list. Names are matched case- and whitespace-insensitively from here on. */
     public static void setFreeIngredients(final String... names) {
         freeIngredients = lowercased(names);
+    }
+
+    public static void resetFreeIngredients() {
+        setFreeIngredients(DEFAULT_FREE_INGREDIENTS);
     }
 
     private static Set<String> lowercased(final String[] names) {

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/AutoBalancer.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/AutoBalancer.java
@@ -173,6 +173,38 @@ public final class AutoBalancer {
     /** Suffix of every wiring-diagnostic note; tests key on it. */
     public static final String MISSING_EDGE = "missing an edge?";
 
+    /**
+     * How loud a solver message is. Carried as a tag on the front of the message rather than
+     * beside it, because notes travel as plain strings from the model through the balance result
+     * to the panel, and a parallel field would have to be threaded through every one of them.
+     */
+    public enum Severity {
+
+        /** The chart has no numbers: nothing was solved. */
+        ERROR,
+        /** Solved, but on something the user probably did not mean - a pin missed, an edge absent. */
+        WARN,
+        /** The solver saying what it did. Nothing to fix. */
+        INFO;
+
+        public String tag() {
+            return "[" + name() + "] ";
+        }
+
+        /** {@code message} with this severity's tag on the front. */
+        public String on(final String message) {
+            return tag() + message;
+        }
+
+        /** The severity {@code note} was raised at; untagged notes are informational. */
+        public static Severity of(final String note) {
+            for (final Severity severity : values()) {
+                if (note.startsWith(severity.tag())) return severity;
+            }
+            return INFO;
+        }
+    }
+
     /** A port on a specific machine. {@code input} distinguishes the two port lists. */
     public record PortRef(UUID nodeId, int portIndex, boolean input) {
 
@@ -527,14 +559,17 @@ public final class AutoBalancer {
                 .thenComparing(Alternative::key));
         boolean complete = skipped == 0;
         if (options.size() > MAX_ALT_OPTIONS) {
-            notes.add("showing the closest " + MAX_ALT_OPTIONS + " of " + options.size() + " workable answers");
+            notes.add(
+                Severity.INFO
+                    .on("showing the closest " + MAX_ALT_OPTIONS + " of " + options.size() + " workable answers"));
             options.subList(MAX_ALT_OPTIONS, options.size())
                 .clear();
             complete = false;
         }
         if (skipped > 0) {
             notes.add(
-                "stopped after " + evaluated
+                Severity.INFO.tag() + "stopped after "
+                    + evaluated
                     + " combinations, so there may be more than the ones listed ("
                     + skipped
                     + " not tried)");
@@ -594,7 +629,9 @@ public final class AutoBalancer {
     private static Attempt applyChoice(final FlowModel ctx, final Run run, final ChoiceKey choice) {
         final Set<Integer> target = ctx.resolve(choice);
         if (target == null) {
-            ctx.notes.add("the saved excess choice no longer fits this chart - showing the solver's own answer");
+            ctx.notes.add(
+                Severity.WARN
+                    .on("the saved excess choice no longer fits this chart - showing the solver's own answer"));
             return run.attempt;
         }
         if (target.equals(run.attempt.support)) return run.attempt;
@@ -603,7 +640,9 @@ public final class AutoBalancer {
         if (alt == null || alt.support.size() != run.attempt.support.size()) {
             // Gate count is the one bar a choice may not fall below: it is a real optimum, where
             // everything after it is a preference the user is entitled to disagree with.
-            ctx.notes.add("the saved excess choice needs more gates than the solver's answer, so it was dropped");
+            ctx.notes.add(
+                Severity.WARN
+                    .on("the saved excess choice needs more gates than the solver's answer, so it was dropped"));
             return run.attempt;
         }
         // Deliberately no note when the pick leans on the outside more than the default would have:
@@ -708,7 +747,9 @@ public final class AutoBalancer {
         }
         final List<String> notes = certified ? List.of()
             : List.of(
-                "gate count " + s1Support.size() + " is minimal but not certified optimal (exact search over budget)");
+                Severity.INFO.on(
+                    "gate count " + s1Support.size()
+                        + " is minimal but not certified optimal (exact search over budget)"));
         // The cap must cover what stage 1 actually used, not what its support reports: a gate
         // carrying flow too small to register still costs its weight, and capping below it leaves
         // stage 2 infeasible on a chart stage 1 has just solved.

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/BalanceView.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/BalanceView.java
@@ -1,6 +1,7 @@
 package com.sbancuz.plannh.data.flowchart;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -110,32 +111,71 @@ public final class BalanceView {
     }
 
     /**
-     * The answers this chart could equally well have had, default first, each marked with what it
-     * gives up. Rebuilds every row and group from the enumeration behind {@link Graph#alternatives()},
-     * so callers drawing every frame want {@link Graph#choices()} rather than this.
+     * The answers this chart could equally well have had, each marked with what it gives up and
+     * which one is on screen. Rebuilds every row and group from the enumeration behind
+     * {@link Graph#alternatives()}, so callers drawing every frame want {@link Graph#choices()}
+     * rather than this. Row order within a decision is {@link #sortedRows}.
      */
     public static Choices choices(final Graph graph) {
         final Alternatives alternatives = graph.alternatives();
         // Grouped by the decision each option answers, in the order the solver emitted them, so a
         // chart posing two questions shows two short lists instead of one list of everything.
-        final Map<AutoBalancer.PortRef, List<Choice>> byDecision = new LinkedHashMap<>();
+        final Map<AutoBalancer.PortRef, List<Alternative>> byDecision = new LinkedHashMap<>();
         final Map<AutoBalancer.PortRef, String> headings = new LinkedHashMap<>();
         for (final Alternative option : alternatives.options()) {
-            final Choice row = new Choice(option.key(), describe(graph, option), reasonOf(option), option.isCurrent());
             byDecision.computeIfAbsent(option.replaces(), k -> new ArrayList<>())
-                .add(row);
+                .add(option);
             if (option.isCurrent()) headings.put(option.replaces(), describe(graph, option));
         }
         final List<Group> groups = new ArrayList<>();
-        for (final Map.Entry<AutoBalancer.PortRef, List<Choice>> entry : byDecision.entrySet()) {
+        for (final Map.Entry<AutoBalancer.PortRef, List<Alternative>> entry : byDecision.entrySet()) {
             // A decision with only its current answer under it is not a decision. Showing it would
             // put a heading above a row that repeats the heading, and imply a choice that is not
             // being offered.
             if (entry.getValue()
                 .size() < 2) continue;
-            groups.add(new Group(headings.getOrDefault(entry.getKey(), ""), List.copyOf(entry.getValue())));
+            final List<Choice> rows = new ArrayList<>();
+            for (final Alternative option : sortedRows(entry.getValue())) {
+                rows.add(new Choice(option.key(), describe(graph, option), reasonOf(option), option.isCurrent()));
+            }
+            groups.add(new Group(headings.getOrDefault(entry.getKey(), ""), List.copyOf(rows)));
         }
         return new Choices(List.copyOf(groups), alternatives.complete(), alternatives.notes());
+    }
+
+    /**
+     * Reading order for one decision's answers: the one on screen first, because it is what the
+     * chart is currently doing and every other row is read against it. The rest are what could
+     * replace it, sorted to be compared rather than to argue - deliberately NOT the solver's
+     * preference order - with what they would bring in ahead of what they would let go of, each
+     * ascending by how much crosses.
+     */
+    private static List<Alternative> sortedRows(final List<Alternative> options) {
+        final List<Alternative> sorted = new ArrayList<>(options);
+        sorted.sort(
+            Comparator.comparing((final Alternative o) -> !o.isCurrent())
+                .thenComparing(o -> !isImport(o))
+                .thenComparingDouble(BalanceView::crossingRate)
+                .thenComparing(Alternative::key));
+        return sorted;
+    }
+
+    /** Whether this answer brings the ingredient in, as opposed to letting a surplus out. */
+    private static boolean isImport(final Alternative option) {
+        return !option.externals()
+            .isEmpty() && option.externals()
+                .get(0)
+                .port()
+                .input();
+    }
+
+    /** How much crosses the boundary under this answer, summed over the ports it uses. */
+    private static double crossingRate(final Alternative option) {
+        double rate = 0;
+        for (final External e : option.externals()) {
+            rate += e.ratePerSecond();
+        }
+        return rate;
     }
 
     /** Whether there is anything to choose between - cheap enough to ask every frame. */

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/BalanceView.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/BalanceView.java
@@ -144,11 +144,9 @@ public final class BalanceView {
     }
 
     /**
-     * Reading order for one decision's answers: the one on screen first, because it is what the
-     * chart is currently doing and every other row is read against it. The rest are what could
-     * replace it, sorted to be compared rather than to argue - deliberately NOT the solver's
-     * preference order - with what they would bring in ahead of what they would let go of, each
-     * ascending by how much crosses.
+     * Reading order for one decision's answers: the one on screen first, since every other row is
+     * read against it, then the rest as a list of amounts - imports before surpluses, each
+     * ascending. Deliberately not the solver's preference order.
      */
     private static List<Alternative> sortedRows(final List<Alternative> options) {
         final List<Alternative> sorted = new ArrayList<>(options);

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/Balancer.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/Balancer.java
@@ -74,10 +74,10 @@ public final class Balancer {
                 // Expected state, not an error: an unpinned chart is just wiring, so it gets
                 // no quantities at all rather than numbers derived from an anchor nobody set.
                 PlanNH.LOG.info("Auto balance idle: {}", result.failure());
-                return unbalanced(graph, result.failure());
+                return unbalanced(graph, AutoBalancer.Severity.INFO.on(result.failure()));
             }
             PlanNH.LOG.warn("Auto balance failed ({}); showing the chart without quantities", result.failure());
-            return unbalanced(graph, "balance failed: " + result.failure());
+            return unbalanced(graph, AutoBalancer.Severity.ERROR.on("balance failed: " + result.failure()));
         }
         final AutoBalancer.Solution solution = result.solution();
         for (final String note : solution.notes()) {

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/FlowModel.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/FlowModel.java
@@ -2,12 +2,15 @@ package com.sbancuz.plannh.data.flowchart;
 
 import static com.sbancuz.plannh.data.flowchart.AutoBalancer.MIN_MODEL_MILLIS;
 import static com.sbancuz.plannh.data.flowchart.AutoBalancer.MISSING_EDGE;
+import static com.sbancuz.plannh.data.flowchart.AutoBalancer.Severity.INFO;
+import static com.sbancuz.plannh.data.flowchart.AutoBalancer.Severity.WARN;
 import static com.sbancuz.plannh.data.flowchart.AutoBalancer.TIE_REL;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -19,6 +22,7 @@ import org.ojalgo.optimisation.Variable;
 import org.ojalgo.optimisation.integer.IntegerStrategy;
 import org.ojalgo.type.context.NumberContext;
 
+import com.sbancuz.plannh.Config;
 import com.sbancuz.plannh.data.MachineConfig;
 import com.sbancuz.plannh.data.flowchart.AutoBalancer.Alternative;
 import com.sbancuz.plannh.data.flowchart.AutoBalancer.Attempt;
@@ -225,10 +229,12 @@ final class FlowModel {
             final double actual = chosenExtent * qty;
             if (actual > t.getValue() * (1 + TIE_REL)) {
                 notes.add(
-                    "'" + m.node.machineName
-                        + "' output "
-                        + t.getKey()
-                        + " overshoots its target: "
+                    WARN.tag() + "'"
+                        + m.node.machineName
+                        + "' overshoots its "
+                        + m.node.outputs.get(t.getKey())
+                            .getDisplayName()
+                        + " target: "
                         + actual
                         + "/s produced for a target of "
                         + t.getValue()
@@ -726,17 +732,29 @@ final class FlowModel {
      * another terminal); (2) a gated source whose ingredient is produced in a DIFFERENT
      * edge-connected component (two unlinked islands of the same fluid). Same-component
      * gated sources are the normal deficit case (e.g. the loopGraph source) and stay quiet.
+     *
+     * <p>
+     * Severities differ because the two smells do: taking an ingredient from outside while the
+     * chart also makes some is routine (nobody wires every input), so smell 1 is an observation.
+     * Two unlinked islands of the SAME ingredient is a chart that does not describe one factory,
+     * so smell 2 is a warning. Ingredients the pack gives away are filtered out of both -
+     * see {@link Config#isFreeIngredient}.
      */
     private List<String> wiringDiagnostics(final Attempt attempt, final double tol, final List<External> terminalIn) {
-        final List<String> result = new ArrayList<>();
+        // A set: the same ingredient imported at two ports of the same machine is one wiring
+        // mistake to the reader, and the message that describes it is identical either way.
+        final Set<String> result = new LinkedHashSet<>();
         for (final External in : terminalIn) {
+            final String ingredient = ingredientNameOf(in);
+            if (Config.isFreeIngredient(ingredient)) continue;
             final String match = findProduction(in, -1);
             if (match != null) {
                 result.add(
-                    "'" + machineNameOf(in)
+                    INFO.tag() + "'"
+                        + machineNameOf(in)
                         + "' imports "
-                        + portNameOf(in)
-                        + " externally, but the chart also produces it at '"
+                        + ingredient
+                        + " externally, but is produced at '"
                         + match
                         + "' - "
                         + MISSING_EDGE);
@@ -748,19 +766,22 @@ final class FlowModel {
             final External src = new External(
                 new PortRef(machines.get(port.machine()).node.id, port.portIndex(), port.input()),
                 attempt.externals[p]);
+            final String ingredient = ingredientNameOf(src);
+            if (Config.isFreeIngredient(ingredient)) continue;
             final String match = findProduction(src, portComponent[p]);
             if (match != null) {
                 result.add(
-                    "'" + machineNameOf(src)
+                    WARN.tag() + "'"
+                        + machineNameOf(src)
                         + "' sources "
-                        + portNameOf(src)
+                        + ingredient
                         + " externally, but an unlinked part of the chart produces it at '"
                         + match
                         + "' - "
                         + MISSING_EDGE);
             }
         }
-        return result;
+        return List.copyOf(result);
     }
 
     /**
@@ -810,10 +831,9 @@ final class FlowModel {
                     .nodeId())).node.machineName;
     }
 
-    private String portNameOf(final External e) {
-        return (e.port()
-            .input() ? "input " : "output ") + e.port()
-                .portIndex();
+    /** The ingredient at a port, named the way the rest of the GUI names it. */
+    private String ingredientNameOf(final External e) {
+        return portOf(e).getDisplayName();
     }
 
     private void collectTerminals(final int m, final MachineData md, final int portCount, final boolean input,

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/Serializer.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/Serializer.java
@@ -20,6 +20,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import com.sbancuz.plannh.PlanNH;
 import com.sbancuz.plannh.data.MachineConfig;
 import com.sbancuz.plannh.data.MachineProfile;
@@ -27,6 +28,7 @@ import com.sbancuz.plannh.data.MachineProfileRegistry;
 import com.sbancuz.plannh.data.SettingDef;
 import com.sbancuz.plannh.data.flowchart.Balancer.BalanceMode;
 import com.sbancuz.plannh.data.flowchart.Summary.SummaryMode;
+import com.sbancuz.plannh.data.flowchart.Summary.SummarySection;
 
 import codechicken.nei.recipe.Recipe;
 
@@ -96,6 +98,11 @@ public final class Serializer {
         root.addProperty("summaryY", set.summaryY);
         root.addProperty("summaryCollapsed", set.summaryCollapsed);
         root.addProperty("summaryMode", set.summaryMode.name());
+        final JsonArray collapsedSections = new JsonArray();
+        for (final SummarySection section : set.collapsedSummarySections) {
+            collapsedSections.add(new JsonPrimitive(section.name()));
+        }
+        root.add("summaryCollapsedSections", collapsedSections);
         final JsonArray arr = new JsonArray();
         for (final SlotSet.Slot slot : set.slots) {
             final JsonObject slotObj = new JsonObject();
@@ -128,6 +135,16 @@ public final class Serializer {
                     root.get("summaryMode")
                         .getAsString());
             } catch (final IllegalArgumentException ignored) {}
+        }
+        // Absent key keeps the defaults, so saves written before sections were foldable open with
+        // the operation list folded like a fresh install.
+        if (root.has("summaryCollapsedSections")) {
+            set.collapsedSummarySections.clear();
+            for (final JsonElement elem : root.getAsJsonArray("summaryCollapsedSections")) {
+                try {
+                    set.collapsedSummarySections.add(SummarySection.valueOf(elem.getAsString()));
+                } catch (final IllegalArgumentException ignored) {}
+            }
         }
         final JsonArray arr = root.getAsJsonArray("slots");
         for (final JsonElement elem : arr) {

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/Serializer.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/Serializer.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -97,19 +98,12 @@ public final class Serializer {
         root.addProperty("summaryY", set.summaryY);
         root.addProperty("summaryCollapsed", set.summaryCollapsed);
         root.addProperty("summaryMode", set.summaryMode.name());
-        // Every section, not just the folded ones: a section this save has never heard of has to
-        // be distinguishable from one the user deliberately left open, or adding a section would
-        // silently unfold it for everyone who had already saved.
-        final JsonObject sectionFolds = new JsonObject();
-        for (final SummarySection section : SummarySection.values()) {
-            sectionFolds.addProperty(section.name(), set.collapsedSummarySections.contains(section));
-        }
-        root.add("summarySectionFolds", sectionFolds);
         final JsonArray arr = new JsonArray();
         for (final SlotSet.Slot slot : set.slots) {
             final JsonObject slotObj = new JsonObject();
             slotObj.addProperty("name", slot.name);
             slotObj.addProperty("data", encode(slot.graph));
+            slotObj.add("sectionFolds", foldsToJson(slot.collapsedSummarySections));
             arr.add(slotObj);
         }
         root.add("slots", arr);
@@ -138,25 +132,6 @@ public final class Serializer {
                         .getAsString());
             } catch (final IllegalArgumentException ignored) {}
         }
-        // Read section by section over the defaults rather than replacing them: an unmentioned
-        // section is one the save predates, and it keeps the fold a fresh install would give it.
-        if (root.has("summarySectionFolds")) {
-            for (final var fold : root.getAsJsonObject("summarySectionFolds")
-                .entrySet()) {
-                final SummarySection section;
-                try {
-                    section = SummarySection.valueOf(fold.getKey());
-                } catch (final IllegalArgumentException ignored) {
-                    continue; // a section this build has dropped
-                }
-                if (fold.getValue()
-                    .getAsBoolean()) {
-                    set.collapsedSummarySections.add(section);
-                } else {
-                    set.collapsedSummarySections.remove(section);
-                }
-            }
-        }
         final JsonArray arr = root.getAsJsonArray("slots");
         for (final JsonElement elem : arr) {
             final JsonObject obj = elem.getAsJsonObject();
@@ -164,19 +139,57 @@ public final class Serializer {
                 .getAsString();
             // One unreadable chart costs that chart, not the save; the empty graph keeps slot
             // numbering in place.
+            SlotSet.Slot slot;
             try {
-                set.slots.add(
-                    new SlotSet.Slot(
-                        name,
-                        decode(
-                            obj.get("data")
-                                .getAsString())));
+                slot = new SlotSet.Slot(
+                    name,
+                    decode(
+                        obj.get("data")
+                            .getAsString()));
             } catch (final RuntimeException e) {
                 PlanNH.LOG.error("Slot '{}' could not be read and was left empty", name, e);
-                set.slots.add(new SlotSet.Slot(name, new Graph()));
+                slot = new SlotSet.Slot(name, new Graph());
             }
+            if (obj.has("sectionFolds")) {
+                foldsFromJson(obj.getAsJsonObject("sectionFolds"), slot.collapsedSummarySections);
+            }
+            set.slots.add(slot);
         }
         return set;
+    }
+
+    /**
+     * Every section, not just the folded ones: a section this save has never heard of has to be
+     * distinguishable from one the user deliberately left open, or adding a section would silently
+     * unfold it for everyone who had already saved.
+     */
+    private static JsonObject foldsToJson(final Set<SummarySection> folded) {
+        final JsonObject folds = new JsonObject();
+        for (final SummarySection section : SummarySection.values()) {
+            folds.addProperty(section.name(), folded.contains(section));
+        }
+        return folds;
+    }
+
+    /**
+     * Reads section by section over whatever {@code folded} already holds rather than replacing it:
+     * an unmentioned section is one the save predates, and it keeps the fold a fresh chart gives it.
+     */
+    private static void foldsFromJson(final JsonObject folds, final Set<SummarySection> folded) {
+        for (final var fold : folds.entrySet()) {
+            final SummarySection section;
+            try {
+                section = SummarySection.valueOf(fold.getKey());
+            } catch (final IllegalArgumentException ignored) {
+                continue; // a section this build has dropped
+            }
+            if (fold.getValue()
+                .getAsBoolean()) {
+                folded.add(section);
+            } else {
+                folded.remove(section);
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/Serializer.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/Serializer.java
@@ -20,7 +20,6 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
 import com.sbancuz.plannh.PlanNH;
 import com.sbancuz.plannh.data.MachineConfig;
 import com.sbancuz.plannh.data.MachineProfile;
@@ -98,11 +97,14 @@ public final class Serializer {
         root.addProperty("summaryY", set.summaryY);
         root.addProperty("summaryCollapsed", set.summaryCollapsed);
         root.addProperty("summaryMode", set.summaryMode.name());
-        final JsonArray collapsedSections = new JsonArray();
-        for (final SummarySection section : set.collapsedSummarySections) {
-            collapsedSections.add(new JsonPrimitive(section.name()));
+        // Every section, not just the folded ones: a section this save has never heard of has to
+        // be distinguishable from one the user deliberately left open, or adding a section would
+        // silently unfold it for everyone who had already saved.
+        final JsonObject sectionFolds = new JsonObject();
+        for (final SummarySection section : SummarySection.values()) {
+            sectionFolds.addProperty(section.name(), set.collapsedSummarySections.contains(section));
         }
-        root.add("summaryCollapsedSections", collapsedSections);
+        root.add("summarySectionFolds", sectionFolds);
         final JsonArray arr = new JsonArray();
         for (final SlotSet.Slot slot : set.slots) {
             final JsonObject slotObj = new JsonObject();
@@ -136,14 +138,23 @@ public final class Serializer {
                         .getAsString());
             } catch (final IllegalArgumentException ignored) {}
         }
-        // Absent key keeps the defaults, so saves written before sections were foldable open with
-        // the operation list folded like a fresh install.
-        if (root.has("summaryCollapsedSections")) {
-            set.collapsedSummarySections.clear();
-            for (final JsonElement elem : root.getAsJsonArray("summaryCollapsedSections")) {
+        // Read section by section over the defaults rather than replacing them: an unmentioned
+        // section is one the save predates, and it keeps the fold a fresh install would give it.
+        if (root.has("summarySectionFolds")) {
+            for (final var fold : root.getAsJsonObject("summarySectionFolds")
+                .entrySet()) {
+                final SummarySection section;
                 try {
-                    set.collapsedSummarySections.add(SummarySection.valueOf(elem.getAsString()));
-                } catch (final IllegalArgumentException ignored) {}
+                    section = SummarySection.valueOf(fold.getKey());
+                } catch (final IllegalArgumentException ignored) {
+                    continue; // a section this build has dropped
+                }
+                if (fold.getValue()
+                    .getAsBoolean()) {
+                    set.collapsedSummarySections.add(section);
+                } else {
+                    set.collapsedSummarySections.remove(section);
+                }
             }
         }
         final JsonArray arr = root.getAsJsonArray("slots");

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/SlotSet.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/SlotSet.java
@@ -12,12 +12,26 @@ public class SlotSet {
     public static final int DEFAULT_SUMMARY_X = 210;
     public static final int DEFAULT_SUMMARY_Y = 46;
 
+    /**
+     * Sections a fresh chart folds away: the reference material, not the answer. Solver messages
+     * stay open - a chart that failed to balance has to say so without being asked.
+     */
+    public static EnumSet<SummarySection> defaultSummaryFolds() {
+        return EnumSet.of(SummarySection.MACHINE_COUNTS, SummarySection.STATISTICS, SummarySection.HELP);
+    }
+
     public static class Slot {
 
         public String name;
         public Graph graph;
         /** Per-slot and session-only: edits also arrive from the NEI overlay with no screen open. */
         public final transient UndoHistory undoHistory = new UndoHistory();
+        /**
+         * Per slot rather than per set: a fold says "not on this chart", and the next chart is a
+         * different question. Inherited globally, one unfolded panel followed the user into every
+         * chart they opened afterwards and there was no way back to the defaults.
+         */
+        public final EnumSet<SummarySection> collapsedSummarySections = defaultSummaryFolds();
 
         public Slot(final String name, final Graph graph) {
             this.name = name;
@@ -31,9 +45,6 @@ public class SlotSet {
     public int summaryY = DEFAULT_SUMMARY_Y;
     public boolean summaryCollapsed = false;
     public SummaryMode summaryMode = SummaryMode.CYCLES;
-    /** Sections folded away in the summary panel: the reference material, not the answer. */
-    public final EnumSet<SummarySection> collapsedSummarySections = EnumSet
-        .of(SummarySection.MACHINE_COUNTS, SummarySection.STATISTICS, SummarySection.MESSAGES, SummarySection.HELP);
 
     /** Clamps activeSlot and guarantees a slot exists. */
     private Slot activeSlot() {
@@ -56,5 +67,10 @@ public class SlotSet {
 
     public UndoHistory getActiveUndoHistory() {
         return activeSlot().undoHistory;
+    }
+
+    /** The summary folds of the chart on screen; mutated in place by the panel's headers. */
+    public EnumSet<SummarySection> getActiveSummaryFolds() {
+        return activeSlot().collapsedSummarySections;
     }
 }

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/SlotSet.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/SlotSet.java
@@ -1,9 +1,11 @@
 package com.sbancuz.plannh.data.flowchart;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 
 import com.sbancuz.plannh.data.flowchart.Summary.SummaryMode;
+import com.sbancuz.plannh.data.flowchart.Summary.SummarySection;
 
 public class SlotSet {
 
@@ -29,6 +31,8 @@ public class SlotSet {
     public int summaryY = DEFAULT_SUMMARY_Y;
     public boolean summaryCollapsed = false;
     public SummaryMode summaryMode = SummaryMode.CYCLES;
+    /** Sections folded away in the summary panel; the per-node operation list starts folded. */
+    public final EnumSet<SummarySection> collapsedSummarySections = EnumSet.of(SummarySection.OPERATIONS);
 
     /** Clamps activeSlot and guarantees a slot exists. */
     private Slot activeSlot() {

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/SlotSet.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/SlotSet.java
@@ -31,8 +31,9 @@ public class SlotSet {
     public int summaryY = DEFAULT_SUMMARY_Y;
     public boolean summaryCollapsed = false;
     public SummaryMode summaryMode = SummaryMode.CYCLES;
-    /** Sections folded away in the summary panel; the per-node operation list starts folded. */
-    public final EnumSet<SummarySection> collapsedSummarySections = EnumSet.of(SummarySection.OPERATIONS);
+    /** Sections folded away in the summary panel: the reference material, not the answer. */
+    public final EnumSet<SummarySection> collapsedSummarySections = EnumSet
+        .of(SummarySection.MACHINE_COUNTS, SummarySection.STATISTICS, SummarySection.MESSAGES, SummarySection.HELP);
 
     /** Clamps activeSlot and guarantees a slot exists. */
     private Slot activeSlot() {

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/SlotSet.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/SlotSet.java
@@ -28,8 +28,7 @@ public class SlotSet {
         public final transient UndoHistory undoHistory = new UndoHistory();
         /**
          * Per slot rather than per set: a fold says "not on this chart", and the next chart is a
-         * different question. Inherited globally, one unfolded panel followed the user into every
-         * chart they opened afterwards and there was no way back to the defaults.
+         * different question.
          */
         public final EnumSet<SummarySection> collapsedSummarySections = defaultSummaryFolds();
 

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/Summary.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/Summary.java
@@ -1,6 +1,7 @@
 package com.sbancuz.plannh.data.flowchart;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,14 +24,18 @@ public record Summary(List<Line<?>> outputs, List<Line<?>> inputs, List<Line<?>>
         THROUGHPUT
     }
 
-    /** The summary panel's collapsible sections, in the order they are drawn. */
+    /**
+     * The summary panel's foldable sections, in the order they are drawn. Only the reference
+     * material folds: the choices, inputs and outputs above them ARE the answer the panel exists
+     * to give, so they have no fold state to keep and are not listed here.
+     */
     public enum SummarySection {
-        CHOICES,
-        INPUTS,
-        OUTPUTS,
-        OPERATIONS,
-        PROPERTIES,
-        NOTES
+        MACHINE_COUNTS,
+        /** Drawn from {@link Summary#properties()}; "Statistics" is what a reader calls them. */
+        STATISTICS,
+        /** Everything the solver had to say, at every severity. */
+        MESSAGES,
+        HELP
     }
 
     public record Line<T> (RecipeProperty<T> label, T resource, float amount) {
@@ -146,11 +151,21 @@ public record Summary(List<Line<?>> outputs, List<Line<?>> inputs, List<Line<?>>
             propertyMap.merge(new LineKey.PropertyKey(entry.getKey()), (float) entry.getValue(), Float::sum);
         }
 
-        return new Summary(flatten(outputMap), flatten(inputMap), flatten(propertyMap));
+        // Sorted opposite ways on purpose: an output list answers "what does this chart make", so
+        // the headline product leads, while an input list is a shopping list and the rarest thing
+        // on it - the one line that will actually be a problem - is the smallest number.
+        // Name breaks ties so a chart carrying two equal flows does not shuffle between frames.
+        return new Summary(
+            flatten(outputMap, BY_AMOUNT.reversed()),
+            flatten(inputMap, BY_AMOUNT),
+            flatten(propertyMap, BY_AMOUNT));
     }
 
+    private static final Comparator<Line<?>> BY_AMOUNT = Comparator.comparingDouble((Line<?> l) -> l.amount())
+        .thenComparing(Line::displayName);
+
     @SuppressWarnings({"rawtypes", "unchecked"})
-    private static List<Line<?>> flatten(final Map<LineKey, Float> map) {
+    private static List<Line<?>> flatten(final Map<LineKey, Float> map, final Comparator<Line<?>> order) {
         final List<Line<?>> result = new ArrayList<>();
         for (final var entry : map.entrySet()) {
             if (entry.getValue() <= 0) continue;
@@ -160,6 +175,7 @@ public record Summary(List<Line<?>> outputs, List<Line<?>> inputs, List<Line<?>>
             };
             result.add(line);
         }
+        result.sort(order);
         return result;
     }
 }

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/Summary.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/Summary.java
@@ -19,6 +19,9 @@ public record Summary(List<Line<?>> outputs, List<Line<?>> inputs, List<Line<?>>
      */
     private static final float NET_EPS = 1e-4f;
 
+    private static final Comparator<Line<?>> BY_AMOUNT = Comparator.comparingDouble((Line<?> l) -> l.amount())
+        .thenComparing(Line::displayName);
+
     public enum SummaryMode {
         CYCLES,
         THROUGHPUT
@@ -151,18 +154,13 @@ public record Summary(List<Line<?>> outputs, List<Line<?>> inputs, List<Line<?>>
             propertyMap.merge(new LineKey.PropertyKey(entry.getKey()), (float) entry.getValue(), Float::sum);
         }
 
-        // Sorted opposite ways on purpose: an output list answers "what does this chart make", so
-        // the headline product leads, while an input list is a shopping list and the rarest thing
-        // on it - the one line that will actually be a problem - is the smallest number.
-        // Name breaks ties so a chart carrying two equal flows does not shuffle between frames.
+        // Opposite ways on purpose: an output list leads with the headline product, an input list
+        // with the scarcest ingredient. Name breaks ties, or equal flows shuffle between frames.
         return new Summary(
             flatten(outputMap, BY_AMOUNT.reversed()),
             flatten(inputMap, BY_AMOUNT),
             flatten(propertyMap, BY_AMOUNT));
     }
-
-    private static final Comparator<Line<?>> BY_AMOUNT = Comparator.comparingDouble((Line<?> l) -> l.amount())
-        .thenComparing(Line::displayName);
 
     @SuppressWarnings({"rawtypes", "unchecked"})
     private static List<Line<?>> flatten(final Map<LineKey, Float> map, final Comparator<Line<?>> order) {

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/Summary.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/Summary.java
@@ -23,6 +23,16 @@ public record Summary(List<Line<?>> outputs, List<Line<?>> inputs, List<Line<?>>
         THROUGHPUT
     }
 
+    /** The summary panel's collapsible sections, in the order they are drawn. */
+    public enum SummarySection {
+        CHOICES,
+        INPUTS,
+        OUTPUTS,
+        OPERATIONS,
+        PROPERTIES,
+        NOTES
+    }
+
     public record Line<T> (RecipeProperty<T> label, T resource, float amount) {
 
         public String displayName() {

--- a/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
+++ b/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
@@ -189,9 +189,7 @@ public class FlowchartScreen extends ModularScreen {
                                     return true;
                                 }))
                         .child(
-                            // Dynamic, and read off the live SlotSet: built as a plain string this
-                            // label kept whichever slot was active when the screen opened, so the
-                            // arrows moved the canvas underneath a number that never followed.
+                            // Dynamic: the arrows move the active slot under this label.
                             IKey.dynamicKey(() -> IKey.str(slotLabel()))
                                 .asWidget()
                                 .color(Color.WHITE.main))
@@ -481,6 +479,28 @@ public class FlowchartScreen extends ModularScreen {
         private final Map<SummarySection, int[]> headerRows = new EnumMap<>(SummarySection.class);
 
         /**
+         * Nodes by descending operation count: the list is read for what to build most of, and the
+         * tail is the part nobody scrolls to. Cached against the balance that ordered them - the
+         * panel draws every frame and the counts only move when the chart is re-solved.
+         */
+        private BalanceResult sortedFor;
+        private List<Node> byOperations = List.of();
+
+        private List<Node> nodesByOperations(final BalanceResult br) {
+            if (br == sortedFor) return byOperations;
+            final List<Node> sorted = new ArrayList<>(graph().getNodes());
+            sorted.sort(Comparator.comparingDouble((final Node node) -> {
+                final NodeBalance nb = br.nodeBalances()
+                    .get(node.id);
+                return nb == null ? 0 : nb.operations();
+            })
+                .reversed());
+            sortedFor = br;
+            byOperations = List.copyOf(sorted);
+            return byOperations;
+        }
+
+        /**
          * Word-wrapped notes, held against the balance that produced them. Wrapping runs the font
          * renderer over every note and is asked for twice a frame - once to measure the panel and
          * again to draw it - where the notes only change when the chart is re-solved. The balance
@@ -514,12 +534,6 @@ public class FlowchartScreen extends ModularScreen {
         /** Header plus, when the section is open, one line per body row. */
         private int sectionHeight(@Nullable final SummarySection section, final int bodyLines) {
             return SECTION_H + (sectionOpen(section) ? bodyLines * LINE_H : 0) + SECTION_END_PAD;
-        }
-
-        private static double operationsOf(final BalanceResult br, final Node node) {
-            final NodeBalance nb = br.nodeBalances()
-                .get(node.id);
-            return nb == null ? 0 : nb.operations();
         }
 
         /**
@@ -609,9 +623,8 @@ public class FlowchartScreen extends ModularScreen {
 
         /**
          * Solver messages, word-wrapped to the summary width at the item text scale and coloured
-         * per severity. Every message shares one section - the tag on the front says how loud it
-         * is, which is finer than a section heading can be and does not hide errors behind a fold
-         * the user closed for warnings.
+         * per severity. One section for every severity: the tag on the front is finer than a
+         * section heading can be, and cheaper than a fold per severity.
          */
         private void wrapNotes(final BalanceResult br) {
             if (br == wrappedFor) return;
@@ -632,15 +645,11 @@ public class FlowchartScreen extends ModularScreen {
             return switch (severity) {
                 case ERROR -> PlannhColors.ACCENT_RED.getColor();
                 case WARN -> PlannhColors.ACCENT_AMBER.getColor();
-                case INFO -> PlannhColors.TEXT_MUTED.getColor();
+                case INFO -> PlannhColors.ACCENT_BLUE.getColor();
             };
         }
 
-        /**
-         * The loudest thing the solver said, which is what the heading has to carry: an alarming
-         * bar over three informational notes cries wolf, and the next real warning reads as more
-         * of the same.
-         */
+        /** The loudest thing the solver said: an alarming bar over three asides cries wolf. */
         private static AutoBalancer.Severity loudest(final BalanceResult br) {
             AutoBalancer.Severity worst = AutoBalancer.Severity.INFO;
             for (final String note : br.notes()) {
@@ -648,17 +657,6 @@ public class FlowchartScreen extends ModularScreen {
                 if (severity.ordinal() < worst.ordinal()) worst = severity;
             }
             return worst;
-        }
-
-        /** Section bar behind the messages heading: the alarming one only when something is wrong. */
-        private static int loudestHeaderColor(final AutoBalancer.Severity worst) {
-            return worst == AutoBalancer.Severity.INFO ? PlannhColors.SECTION_OPS.getColor()
-                : PlannhColors.SECTION_WARN.getColor();
-        }
-
-        /** Heading text, which unlike a message line has to stay legible against its own bar. */
-        private static int loudestTitleColor(final AutoBalancer.Severity worst) {
-            return worst == AutoBalancer.Severity.INFO ? PlannhColors.ACCENT_BLUE.getColor() : severityColor(worst);
         }
 
         @Override
@@ -742,8 +740,9 @@ public class FlowchartScreen extends ModularScreen {
                     SummarySection.MESSAGES,
                     "Solver Messages (" + br.notes()
                         .size() + ")",
-                    loudestHeaderColor(worst),
-                    loudestTitleColor(worst));
+                    worst == AutoBalancer.Severity.INFO ? PlannhColors.SECTION_OPS.getColor()
+                        : PlannhColors.SECTION_WARN.getColor(),
+                    severityColor(worst));
                 if (sectionOpen(SummarySection.MESSAGES)) {
                     for (final MessageLine line : wrappedMessages) {
                         GuiDraw.drawText(line.text(), ITEM_TEXT_X, ly, NOTE_SCALE, line.color(), false);
@@ -843,10 +842,9 @@ public class FlowchartScreen extends ModularScreen {
         }
 
         /**
-         * A section heading, clickable when the section folds. The fold marker doubles as the
-         * affordance: a section whose body is off still keeps its header, or there would be
-         * nothing left to click to get it back. A null section draws the bar alone - no marker
-         * and no hit area, because there is nothing to toggle.
+         * A section heading, clickable when the section folds. A folded section keeps its header,
+         * or there would be nothing left to click to get it back; a null section draws the bar
+         * alone, with no marker and no hit area.
          */
         private int drawSectionHeader(final int ly, final int w, @Nullable final SummarySection section,
             final String title, final int headerColor, final int titleColor) {
@@ -877,13 +875,7 @@ public class FlowchartScreen extends ModularScreen {
                 PlannhColors.ACCENT_BLUE.getColor());
             if (!sectionOpen(SummarySection.MACHINE_COUNTS)) return ly + SECTION_END_PAD;
 
-            // Busiest machine first: on a chart with thirty nodes the list is read for what to
-            // build most of, and the tail is the part nobody scrolls to.
-            final List<Node> byCount = new ArrayList<>(graph().getNodes());
-            byCount.sort(
-                Comparator.comparingDouble((final Node n) -> operationsOf(br, n))
-                    .reversed());
-            for (final Node node : byCount) {
+            for (final Node node : nodesByOperations(br)) {
                 final NodeBalance nb = br.nodeBalances()
                     .get(node.id);
                 if (nb == null || nb.operations() <= 0) continue;

--- a/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
+++ b/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
@@ -3,11 +3,13 @@ package com.sbancuz.plannh.gui;
 import static codechicken.lib.gui.GuiDraw.drawMultilineTip;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
@@ -36,6 +38,7 @@ import com.cleanroommc.modularui.widgets.ListWidget;
 import com.cleanroommc.modularui.widgets.layout.Flow;
 import com.cleanroommc.modularui.widgets.menu.Menu;
 import com.cleanroommc.modularui.widgets.textfield.TextFieldWidget;
+import com.sbancuz.plannh.Config;
 import com.sbancuz.plannh.PlanNH;
 import com.sbancuz.plannh.api.PlanAPI;
 import com.sbancuz.plannh.data.flowchart.AutoBalancer;
@@ -423,12 +426,12 @@ public class FlowchartScreen extends ModularScreen {
         private static final int SEPARATOR_Y_OFF = 2;
         private static final int MODE_TEXT_X = 6;
         private static final int MODE_LINE_H = 12;
-        private static final int HELP_SEP_Y_OFF = 4;
-        private static final int HELP_SEP_GAP = 10;
         private static final int ZOOM_TEXT_X = 6;
         private static final int ZOOM_LINE_H = 14;
-        private static final int HELP_LINE_H = 10;
         private static final float NOTE_SCALE = 0.8f;
+
+        private static final String[] HELP_LINES = { "[Scroll] zoom", "[LMB drag] move node", "[R/U] open NEI",
+            "[+ in NEI GUI] add recipe" };
 
         private final CanvasWidget canvas;
 
@@ -474,7 +477,7 @@ public class FlowchartScreen extends ModularScreen {
          * object's identity is the same "has it been re-solved" proxy the router uses.
          */
         private BalanceResult wrappedFor;
-        private List<String> wrapped = List.of();
+        private List<MessageLine> wrappedMessages = List.of();
 
         private boolean choicesOffered(final BalanceResult br) {
             return BalanceView.hasChoices(graph());
@@ -491,17 +494,28 @@ public class FlowchartScreen extends ModularScreen {
                 .size() + headings;
         }
 
-        private boolean sectionOpen(final SummarySection section) {
-            return !PlanAPI.getSlotSet().collapsedSummarySections.contains(section);
+        /** A null section is one that does not fold, and an unfoldable section is always open. */
+        private boolean sectionOpen(@Nullable final SummarySection section) {
+            return section == null || !PlanAPI.getSlotSet().collapsedSummarySections.contains(section);
         }
 
         /** Header plus, when the section is open, one line per body row. */
-        private int sectionHeight(final SummarySection section, final int bodyLines) {
+        private int sectionHeight(@Nullable final SummarySection section, final int bodyLines) {
             return SECTION_H + (sectionOpen(section) ? bodyLines * LINE_H : 0) + SECTION_END_PAD;
         }
 
-        /** Operation lines: one per node that ran, plus the ops/cycle totals line. */
-        private int operationLineCount(final BalanceResult br) {
+        private static double operationsOf(final BalanceResult br, final Node node) {
+            final NodeBalance nb = br.nodeBalances()
+                .get(node.id);
+            return nb == null ? 0 : nb.operations();
+        }
+
+        /**
+         * Machine-count lines: one per node that ran, plus the ops/cycle totals line. Zero when the
+         * config hides the section, which is what keeps the height and the draw agreeing about it.
+         */
+        private int machineCountLines(final BalanceResult br) {
+            if (Config.hideMachineCountsSection) return 0;
             int lines = br.totalOperations() > 0 || br.totalDurationTicks() > 0 ? 1 : 0;
             for (final Node node : graph().getNodes()) {
                 final NodeBalance nb = br.nodeBalances()
@@ -516,38 +530,38 @@ public class FlowchartScreen extends ModularScreen {
             int h = TITLE_H + SECTION_LY_OFFSET;
 
             if (choicesOffered(br)) {
-                h += sectionHeight(SummarySection.CHOICES, choiceLineCount(br));
+                h += sectionHeight(null, choiceLineCount(br));
             }
             if (!summary.inputs()
                 .isEmpty()) {
                 h += sectionHeight(
-                    SummarySection.INPUTS,
+                    null,
                     summary.inputs()
                         .size());
             }
             if (!summary.outputs()
                 .isEmpty()) {
                 h += sectionHeight(
-                    SummarySection.OUTPUTS,
+                    null,
                     summary.outputs()
                         .size());
             }
-            final int opLines = operationLineCount(br);
-            if (opLines > 0) {
-                h += sectionHeight(SummarySection.OPERATIONS, opLines);
+            final int countLines = machineCountLines(br);
+            if (countLines > 0) {
+                h += sectionHeight(SummarySection.MACHINE_COUNTS, countLines);
             }
             if (!summary.properties()
                 .isEmpty()) {
                 h += sectionHeight(
-                    SummarySection.PROPERTIES,
+                    SummarySection.STATISTICS,
                     summary.properties()
                         .size());
             }
-            if (!br.notes()
-                .isEmpty()) {
-                h += sectionHeight(SummarySection.NOTES, wrapNotes(br).size());
+            wrapNotes(br);
+            if (!wrappedMessages.isEmpty()) {
+                h += sectionHeight(SummarySection.MESSAGES, wrappedMessages.size());
             }
-            h += MODE_LINE_H + HELP_SEP_GAP + ZOOM_LINE_H + HELP_LINE_H * 5 + SECTION_END_PAD;
+            h += MODE_LINE_H + ZOOM_LINE_H + sectionHeight(SummarySection.HELP, HELP_LINES.length) + SECTION_END_PAD;
             return h;
         }
 
@@ -578,20 +592,49 @@ public class FlowchartScreen extends ModularScreen {
             return kept;
         }
 
-        /** Solver notes, word-wrapped to the summary width at the item text scale. */
-        private List<String> wrapNotes(final BalanceResult br) {
-            if (br == wrappedFor) return wrapped;
-            final List<String> lines = new ArrayList<>();
+        /** One drawn line of a solver message, coloured by the severity of the note it came from. */
+        private record MessageLine(String text, int color) {}
+
+        /**
+         * Solver messages, word-wrapped to the summary width at the item text scale and coloured
+         * per severity. Every message shares one section - the tag on the front says how loud it
+         * is, which is finer than a section heading can be and does not hide errors behind a fold
+         * the user closed for warnings.
+         */
+        private void wrapNotes(final BalanceResult br) {
+            if (br == wrappedFor) return;
+            final List<MessageLine> lines = new ArrayList<>();
             final int wrapWidth = (int) ((WIDTH - ITEM_TEXT_X - 4) / NOTE_SCALE);
             for (final String note : br.notes()) {
+                final int color = severityColor(AutoBalancer.Severity.of(note));
                 for (final Object line : Minecraft.getMinecraft().fontRenderer
                     .listFormattedStringToWidth("- " + note, wrapWidth)) {
-                    lines.add((String) line);
+                    lines.add(new MessageLine((String) line, color));
                 }
             }
             wrappedFor = br;
-            wrapped = List.copyOf(lines);
-            return wrapped;
+            wrappedMessages = List.copyOf(lines);
+        }
+
+        private static int severityColor(final AutoBalancer.Severity severity) {
+            return switch (severity) {
+                case ERROR -> PlannhColors.ACCENT_RED.getColor();
+                case WARN -> PlannhColors.ACCENT_AMBER.getColor();
+                case INFO -> PlannhColors.TEXT_MUTED.getColor();
+            };
+        }
+
+        /**
+         * The heading takes the colour of the loudest message under it: folded by default, the bar
+         * is all the user sees, so it has to carry whether anything down there is on fire.
+         */
+        private static int loudestColor(final BalanceResult br) {
+            AutoBalancer.Severity worst = AutoBalancer.Severity.INFO;
+            for (final String note : br.notes()) {
+                final AutoBalancer.Severity severity = AutoBalancer.Severity.of(note);
+                if (severity.ordinal() < worst.ordinal()) worst = severity;
+            }
+            return severityColor(worst);
         }
 
         @Override
@@ -631,7 +674,7 @@ public class FlowchartScreen extends ModularScreen {
             ly = drawSection(
                 ly,
                 w,
-                SummarySection.INPUTS,
+                null,
                 "Inputs",
                 s.inputs(),
                 PlannhColors.SECTION_INPUT.getColor(),
@@ -643,7 +686,7 @@ public class FlowchartScreen extends ModularScreen {
             ly = drawSection(
                 ly,
                 w,
-                SummarySection.OUTPUTS,
+                null,
                 "Outputs",
                 s.outputs(),
                 PlannhColors.SECTION_PRODUCT.getColor(),
@@ -652,34 +695,33 @@ public class FlowchartScreen extends ModularScreen {
                 cycleSecs,
                 isCycle);
 
-            ly = drawOperations(ly, w, br, isCycle);
+            ly = drawMachineCounts(ly, w, br, isCycle);
 
             ly = drawSection(
                 ly,
                 w,
-                SummarySection.PROPERTIES,
-                "Properties",
+                SummarySection.STATISTICS,
+                "Statistics",
                 s.properties(),
                 PlannhColors.SECTION_OPS.getColor(),
-                PlannhColors.SECTION_OPS.getColor(),
+                PlannhColors.ACCENT_BLUE.getColor(),
                 PlannhColors.ACCENT_BLUE.getColor(),
                 cycleSecs,
                 isCycle);
 
-            if (!br.notes()
-                .isEmpty()) {
+            wrapNotes(br);
+            if (!wrappedMessages.isEmpty()) {
                 ly = drawSectionHeader(
                     ly,
                     w,
-                    SummarySection.NOTES,
-                    "Notes (" + br.notes()
+                    SummarySection.MESSAGES,
+                    "Solver Messages (" + br.notes()
                         .size() + ")",
-                    PlannhColors.SECTION_OPS.getColor(),
-                    PlannhColors.ACCENT_AMBER.getColor());
-                if (sectionOpen(SummarySection.NOTES)) {
-                    for (final String line : wrapNotes(br)) {
-                        GuiDraw
-                            .drawText(line, ITEM_TEXT_X, ly, NOTE_SCALE, PlannhColors.ACCENT_AMBER.getColor(), false);
+                    PlannhColors.SECTION_WARN.getColor(),
+                    loudestColor(br));
+                if (sectionOpen(SummarySection.MESSAGES)) {
+                    for (final MessageLine line : wrappedMessages) {
+                        GuiDraw.drawText(line.text(), ITEM_TEXT_X, ly, NOTE_SCALE, line.color(), false);
                         ly += LINE_H;
                     }
                 }
@@ -694,14 +736,6 @@ public class FlowchartScreen extends ModularScreen {
             GuiDraw.drawRect(0, ly - SEPARATOR_Y_OFF, w, 1, PlannhColors.SEPARATOR_LIGHT.getColor());
             GuiDraw.drawText(modeStr, MODE_TEXT_X, ly, 0.9f, PlannhColors.ACCENT_BLUE.getColor(), false);
             ly += MODE_LINE_H;
-
-            GuiDraw.drawRect(
-                SECTION_HEADER_X,
-                ly + HELP_SEP_Y_OFF,
-                w - SECTION_HEADER_X * 2,
-                1,
-                PlannhColors.SEPARATOR_DIM.getColor());
-            ly += HELP_SEP_GAP;
             GuiDraw.drawText(
                 "Zoom: " + Math.round(
                     canvas.getGraph()
@@ -713,15 +747,20 @@ public class FlowchartScreen extends ModularScreen {
                 PlannhColors.TEXT_MUTED.getColor(),
                 false);
             ly += ZOOM_LINE_H;
-            GuiDraw.drawText("[Scroll] zoom", 6, ly, 0.8f, PlannhColors.TEXT_FAINT.getColor(), false);
-            ly += HELP_LINE_H;
-            GuiDraw.drawText("[MMB] pan", 6, ly, 0.8f, PlannhColors.TEXT_FAINT.getColor(), false);
-            ly += HELP_LINE_H;
-            GuiDraw.drawText("[LMB drag] move node", 6, ly, 0.8f, PlannhColors.TEXT_FAINT.getColor(), false);
-            ly += HELP_LINE_H;
-            GuiDraw.drawText("[Double-click] open NEI", 6, ly, 0.8f, PlannhColors.TEXT_FAINT.getColor(), false);
-            ly += HELP_LINE_H;
-            GuiDraw.drawText("[+ in NEI GUI] add recipe", 6, ly, 0.8f, PlannhColors.TEXT_FAINT.getColor(), false);
+
+            ly = drawSectionHeader(
+                ly,
+                w,
+                SummarySection.HELP,
+                "Help",
+                PlannhColors.SECTION_OPS.getColor(),
+                PlannhColors.TEXT_MUTED.getColor());
+            if (sectionOpen(SummarySection.HELP)) {
+                for (final String line : HELP_LINES) {
+                    GuiDraw.drawText(line, ITEM_TEXT_X, ly, 0.8f, PlannhColors.TEXT_FAINT.getColor(), false);
+                    ly += LINE_H;
+                }
+            }
         }
 
         /**
@@ -742,12 +781,11 @@ public class FlowchartScreen extends ModularScreen {
             ly = drawSectionHeader(
                 ly,
                 w,
-                SummarySection.CHOICES,
+                null,
                 "Choices (" + alts.rows()
                     .size() + ")",
                 PlannhColors.SECTION_CHOICE.getColor(),
                 PlannhColors.ACCENT_CYAN2.getColor());
-            if (!sectionOpen(SummarySection.CHOICES)) return ly + SECTION_END_PAD;
 
             // A heading per decision only when there is more than one: with a single question the
             // heading would just repeat the row directly under it.
@@ -780,38 +818,47 @@ public class FlowchartScreen extends ModularScreen {
         }
 
         /**
-         * A clickable section heading. The fold marker doubles as the affordance: a section whose
-         * body is off still keeps its header, or there would be nothing left to click to get it
-         * back.
+         * A section heading, clickable when the section folds. The fold marker doubles as the
+         * affordance: a section whose body is off still keeps its header, or there would be
+         * nothing left to click to get it back. A null section draws the bar alone - no marker
+         * and no hit area, because there is nothing to toggle.
          */
-        private int drawSectionHeader(final int ly, final int w, final SummarySection section, final String title,
-            final int headerColor, final int titleColor) {
+        private int drawSectionHeader(final int ly, final int w, @Nullable final SummarySection section,
+            final String title, final int headerColor, final int titleColor) {
             GuiDraw.drawRect(SECTION_HEADER_X, ly, w - SECTION_HEADER_X * 2, SECTION_H, headerColor);
             GuiDraw.drawText(title, SECTION_HEADER_TEXT_X, ly + SECTION_HEADER_TEXT_Y_OFF, 1.0f, titleColor, false);
-            GuiDraw.drawText(
-                sectionOpen(section) ? "\u2212" : "+",
-                w - SECTION_TOGGLE_X_OFF,
-                ly + SECTION_HEADER_TEXT_Y_OFF,
-                1.0f,
-                titleColor,
-                false);
-            headerRows.put(section, new int[] { ly, ly + SECTION_H });
+            if (section != null) {
+                GuiDraw.drawText(
+                    sectionOpen(section) ? "\u2212" : "+",
+                    w - SECTION_TOGGLE_X_OFF,
+                    ly + SECTION_HEADER_TEXT_Y_OFF,
+                    1.0f,
+                    titleColor,
+                    false);
+                headerRows.put(section, new int[] { ly, ly + SECTION_H });
+            }
             return ly + SECTION_H;
         }
 
         /** Per-node operation counts and the run totals, folded away by default. */
-        private int drawOperations(int ly, final int w, final BalanceResult br, final boolean isCycle) {
-            if (operationLineCount(br) == 0) return ly;
+        private int drawMachineCounts(int ly, final int w, final BalanceResult br, final boolean isCycle) {
+            if (machineCountLines(br) == 0) return ly;
             ly = drawSectionHeader(
                 ly,
                 w,
-                SummarySection.OPERATIONS,
-                "Operations",
+                SummarySection.MACHINE_COUNTS,
+                "Machine Counts",
                 PlannhColors.SECTION_OPS.getColor(),
                 PlannhColors.ACCENT_BLUE.getColor());
-            if (!sectionOpen(SummarySection.OPERATIONS)) return ly + SECTION_END_PAD;
+            if (!sectionOpen(SummarySection.MACHINE_COUNTS)) return ly + SECTION_END_PAD;
 
-            for (final Node node : graph().getNodes()) {
+            // Busiest machine first: on a chart with thirty nodes the list is read for what to
+            // build most of, and the tail is the part nobody scrolls to.
+            final List<Node> byCount = new ArrayList<>(graph().getNodes());
+            byCount.sort(
+                Comparator.comparingDouble((final Node n) -> operationsOf(br, n))
+                    .reversed());
+            for (final Node node : byCount) {
                 final NodeBalance nb = br.nodeBalances()
                     .get(node.id);
                 if (nb == null || nb.operations() <= 0) continue;
@@ -851,7 +898,7 @@ public class FlowchartScreen extends ModularScreen {
             return ly + SECTION_END_PAD;
         }
 
-        private int drawSection(int ly, final int w, final SummarySection section, final String title,
+        private int drawSection(int ly, final int w, @Nullable final SummarySection section, final String title,
             final List<Summary.Line<?>> items, final int headerColor, final int titleColor, final int itemColor,
             final float cycleSecs, final boolean isCycle) {
             if (items.isEmpty()) return ly;

--- a/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
+++ b/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
@@ -3,7 +3,9 @@ package com.sbancuz.plannh.gui;
 import static codechicken.lib.gui.GuiDraw.drawMultilineTip;
 
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.annotation.Nonnull;
 
@@ -46,6 +48,7 @@ import com.sbancuz.plannh.data.flowchart.Node;
 import com.sbancuz.plannh.data.flowchart.SlotSet;
 import com.sbancuz.plannh.data.flowchart.Summary;
 import com.sbancuz.plannh.data.flowchart.Summary.SummaryMode;
+import com.sbancuz.plannh.data.flowchart.Summary.SummarySection;
 import com.sbancuz.plannh.gui.components.CycleButton;
 import com.sbancuz.plannh.nei.NEIPlanConfig;
 
@@ -416,9 +419,8 @@ public class FlowchartScreen extends ModularScreen {
         private static final int SECTION_HEADER_TEXT_Y_OFF = 1;
         private static final int ITEM_TEXT_X = 10;
         private static final int SECTION_END_PAD = 4;
+        private static final int SECTION_TOGGLE_X_OFF = 12;
         private static final int SEPARATOR_Y_OFF = 2;
-        private static final int TOTALS_TEXT_X = 6;
-        private static final int TOTALS_LINE_H = 14;
         private static final int MODE_TEXT_X = 6;
         private static final int MODE_LINE_H = 12;
         private static final int HELP_SEP_Y_OFF = 4;
@@ -462,7 +464,8 @@ public class FlowchartScreen extends ModularScreen {
 
         /** Screen Y of each listed choice, filled during draw and read back on click. */
         private final List<int[]> choiceRows = new ArrayList<>();
-        private int choicesHeaderY = -1;
+        /** Screen Y span of each section header, same draw-then-read-back deal as the choices. */
+        private final Map<SummarySection, int[]> headerRows = new EnumMap<>(SummarySection.class);
 
         /**
          * Word-wrapped notes, held against the balance that produced them. Wrapping runs the font
@@ -488,47 +491,68 @@ public class FlowchartScreen extends ModularScreen {
                 .size() + headings;
         }
 
+        private boolean sectionOpen(final SummarySection section) {
+            return !PlanAPI.getSlotSet().collapsedSummarySections.contains(section);
+        }
+
+        /** Header plus, when the section is open, one line per body row. */
+        private int sectionHeight(final SummarySection section, final int bodyLines) {
+            return SECTION_H + (sectionOpen(section) ? bodyLines * LINE_H : 0) + SECTION_END_PAD;
+        }
+
+        /** Operation lines: one per node that ran, plus the ops/cycle totals line. */
+        private int operationLineCount(final BalanceResult br) {
+            int lines = br.totalOperations() > 0 || br.totalDurationTicks() > 0 ? 1 : 0;
+            for (final Node node : graph().getNodes()) {
+                final NodeBalance nb = br.nodeBalances()
+                    .get(node.id);
+                if (nb != null && nb.operations() > 0) lines++;
+            }
+            return lines;
+        }
+
         private int computeHeight(final Summary summary, final BalanceResult br) {
             if (collapsed) return TITLE_H;
-            final Graph g = graph();
             int h = TITLE_H + SECTION_LY_OFFSET;
 
-            if (!summary.outputs()
-                .isEmpty()) {
-                h += SECTION_H + summary.outputs()
-                    .size() * LINE_H + SECTION_END_PAD;
+            if (choicesOffered(br)) {
+                h += sectionHeight(SummarySection.CHOICES, choiceLineCount(br));
             }
             if (!summary.inputs()
                 .isEmpty()) {
-                h += SECTION_H + summary.inputs()
-                    .size() * LINE_H + SECTION_END_PAD;
+                h += sectionHeight(
+                    SummarySection.INPUTS,
+                    summary.inputs()
+                        .size());
+            }
+            if (!summary.outputs()
+                .isEmpty()) {
+                h += sectionHeight(
+                    SummarySection.OUTPUTS,
+                    summary.outputs()
+                        .size());
+            }
+            final int opLines = operationLineCount(br);
+            if (opLines > 0) {
+                h += sectionHeight(SummarySection.OPERATIONS, opLines);
             }
             if (!summary.properties()
                 .isEmpty()) {
-                h += SECTION_H + summary.properties()
-                    .size() * LINE_H + SECTION_END_PAD;
-            }
-            if (br.totalOperations() > 0) {
-                h += SECTION_H + g.getNodes()
-                    .size() * LINE_H + SECTION_END_PAD;
-            }
-            if (br.totalDurationTicks() > 0) {
-                h += SECTION_H;
-            }
-            if (choicesOffered(br)) {
-                h += SECTION_H + choiceLineCount(br) * LINE_H + SECTION_END_PAD;
+                h += sectionHeight(
+                    SummarySection.PROPERTIES,
+                    summary.properties()
+                        .size());
             }
             if (!br.notes()
                 .isEmpty()) {
-                h += SECTION_H + wrapNotes(br).size() * LINE_H + SECTION_END_PAD;
+                h += sectionHeight(SummarySection.NOTES, wrapNotes(br).size());
             }
-            h += SECTION_LY_OFFSET + TOTALS_LINE_H + 1 + HELP_LINE_H;
-            h += MODE_LINE_H + HELP_LINE_H * 5;
+            h += MODE_LINE_H + HELP_SEP_GAP + ZOOM_LINE_H + HELP_LINE_H * 5 + SECTION_END_PAD;
             return h;
         }
 
         /**
-         * Products/inputs whose amount survives display rounding: netting float residue would
+         * Outputs/inputs whose amount survives display rounding: netting float residue would
          * otherwise print as a "0mB/s" line.
          */
         private Summary displayedSummary(final Summary s, final BalanceResult br) {
@@ -586,7 +610,11 @@ public class FlowchartScreen extends ModularScreen {
                 1.0f,
                 PlannhColors.TEXT_MUTED.getColor(),
                 false);
-            if (collapsed) return;
+            headerRows.clear();
+            if (collapsed) {
+                choiceRows.clear();
+                return;
+            }
 
             final Graph g = graph();
             final BalanceResult br = g.balance();
@@ -597,21 +625,14 @@ public class FlowchartScreen extends ModularScreen {
             final boolean isCycle = sMode == SummaryMode.CYCLES;
             int ly = TITLE_H + SECTION_LY_OFFSET;
 
-            ly = drawSection(
-                ly,
-                w,
-                "Products",
-                s.outputs(),
-                PlannhColors.SECTION_PRODUCT.getColor(),
-                PlannhColors.ACCENT_AMBER.getColor(),
-                PlannhColors.ACCENT_AMBER.getColor(),
-                cycleSecs,
-                isCycle);
+            // Chronological reading order: what was decided, what goes in, what comes out, what runs.
+            ly = drawChoices(ly, w, br);
 
             ly = drawSection(
                 ly,
                 w,
-                "External Inputs",
+                SummarySection.INPUTS,
+                "Inputs",
                 s.inputs(),
                 PlannhColors.SECTION_INPUT.getColor(),
                 PlannhColors.ACCENT_GREEN2.getColor(),
@@ -619,109 +640,60 @@ public class FlowchartScreen extends ModularScreen {
                 cycleSecs,
                 isCycle);
 
-            if (!s.properties()
-                .isEmpty()) {
+            ly = drawSection(
+                ly,
+                w,
+                SummarySection.OUTPUTS,
+                "Outputs",
+                s.outputs(),
+                PlannhColors.SECTION_PRODUCT.getColor(),
+                PlannhColors.ACCENT_AMBER.getColor(),
+                PlannhColors.ACCENT_AMBER.getColor(),
+                cycleSecs,
+                isCycle);
 
-                ly = drawSection(
+            ly = drawOperations(ly, w, br, isCycle);
+
+            ly = drawSection(
+                ly,
+                w,
+                SummarySection.PROPERTIES,
+                "Properties",
+                s.properties(),
+                PlannhColors.SECTION_OPS.getColor(),
+                PlannhColors.SECTION_OPS.getColor(),
+                PlannhColors.ACCENT_BLUE.getColor(),
+                cycleSecs,
+                isCycle);
+
+            if (!br.notes()
+                .isEmpty()) {
+                ly = drawSectionHeader(
                     ly,
                     w,
-                    "Properties",
-                    s.properties(),
+                    SummarySection.NOTES,
+                    "Notes (" + br.notes()
+                        .size() + ")",
                     PlannhColors.SECTION_OPS.getColor(),
-                    PlannhColors.SECTION_OPS.getColor(),
-                    PlannhColors.ACCENT_BLUE.getColor(),
-                    cycleSecs,
-                    isCycle);
-            }
-
-            if (br.totalOperations() > 0) {
-                GuiDraw.drawRect(
-                    SECTION_HEADER_X,
-                    ly,
-                    w - SECTION_HEADER_X * 2,
-                    SECTION_H,
-                    PlannhColors.SECTION_OPS.getColor());
-                GuiDraw.drawText(
-                    "Operations",
-                    SECTION_HEADER_TEXT_X,
-                    ly + SECTION_HEADER_TEXT_Y_OFF,
-                    1.0f,
-                    PlannhColors.ACCENT_BLUE.getColor(),
-                    false);
-                ly += SECTION_H;
-                for (final Node node : g.getNodes()) {
-                    final NodeBalance nb = br.nodeBalances()
-                        .get(node.id);
-                    if (nb == null || nb.operations() <= 0) continue;
-                    GuiDraw.drawText(
-                        "\u00d7" + GuiHelper.formatCount(nb.operations()) + "  " + node.machineName,
-                        ITEM_TEXT_X,
-                        ly,
-                        0.8f,
-                        PlannhColors.TEXT_LIGHT.getColor(),
-                        false);
-                    ly += LINE_H;
+                    PlannhColors.ACCENT_AMBER.getColor());
+                if (sectionOpen(SummarySection.NOTES)) {
+                    for (final String line : wrapNotes(br)) {
+                        GuiDraw
+                            .drawText(line, ITEM_TEXT_X, ly, NOTE_SCALE, PlannhColors.ACCENT_AMBER.getColor(), false);
+                        ly += LINE_H;
+                    }
                 }
                 ly += SECTION_END_PAD;
             }
 
-            if (br.totalOperations() > 0 || br.totalDurationTicks() > 0) {
-                final StringBuilder totals = new StringBuilder();
-                if (br.totalOperations() > 0) totals.append("Ops: ")
-                    .append(GuiHelper.formatCount(br.totalOperations()));
-                if (br.totalDurationTicks() > 0) {
-                    final float sec = (float) br.totalDurationTicks() / GuiHelper.TICKS_PER_SECOND;
-                    if (!totals.isEmpty()) totals.append("  ");
-                    if (isCycle) {
-                        totals.append("Time: ")
-                            .append(br.totalDurationTicks())
-                            .append("t");
-                        if (sec > 0) totals.append(" (")
-                            .append(String.format("%.1f", sec))
-                            .append("s/cycle)");
-                    } else {
-                        totals.append("Cycle: ")
-                            .append(String.format("%.1f", sec))
-                            .append("s");
-                    }
-                }
-                GuiDraw.drawRect(0, ly - SEPARATOR_Y_OFF, w, 1, PlannhColors.SEPARATOR_LIGHT.getColor());
-                GuiDraw
-                    .drawText(totals.toString(), TOTALS_TEXT_X, ly, 0.9f, PlannhColors.ACCENT_BLUE.getColor(), false);
-                ly += TOTALS_LINE_H;
-            }
-
+            // Below the fold: what the chart is, rather than what is in it.
             final BalanceMode mode = g.getBalanceMode();
             final String modeStr = String.format(
                 StatCollector.translateToLocal("plannh.gui.balancer_mode"),
                 String.format(mode.displayName(), g.isOpsMode() ? ", ops" : ""));
+            GuiDraw.drawRect(0, ly - SEPARATOR_Y_OFF, w, 1, PlannhColors.SEPARATOR_LIGHT.getColor());
             GuiDraw.drawText(modeStr, MODE_TEXT_X, ly, 0.9f, PlannhColors.ACCENT_BLUE.getColor(), false);
             ly += MODE_LINE_H;
-
-            ly = drawChoices(ly, w, br);
-
-            if (!br.notes()
-                .isEmpty()) {
-                GuiDraw.drawRect(
-                    SECTION_HEADER_X,
-                    ly,
-                    w - SECTION_HEADER_X * 2,
-                    SECTION_H,
-                    PlannhColors.SECTION_OPS.getColor());
-                GuiDraw.drawText(
-                    "Notes",
-                    SECTION_HEADER_TEXT_X,
-                    ly + SECTION_HEADER_TEXT_Y_OFF,
-                    1.0f,
-                    PlannhColors.ACCENT_AMBER.getColor(),
-                    false);
-                ly += SECTION_H;
-                for (final String line : wrapNotes(br)) {
-                    GuiDraw.drawText(line, ITEM_TEXT_X, ly, NOTE_SCALE, PlannhColors.ACCENT_AMBER.getColor(), false);
-                    ly += LINE_H;
-                }
-                ly += SECTION_END_PAD;
-            }
 
             GuiDraw.drawRect(
                 SECTION_HEADER_X,
@@ -764,26 +736,18 @@ public class FlowchartScreen extends ModularScreen {
          */
         private int drawChoices(int ly, final int w, final BalanceResult br) {
             choiceRows.clear();
-            choicesHeaderY = -1;
             if (!choicesOffered(br)) return ly;
 
             final BalanceView.Choices alts = graph().choices();
-            choicesHeaderY = ly;
-            GuiDraw.drawRect(
-                SECTION_HEADER_X,
+            ly = drawSectionHeader(
                 ly,
-                w - SECTION_HEADER_X * 2,
-                SECTION_H,
-                PlannhColors.SECTION_CHOICE.getColor());
-            GuiDraw.drawText(
+                w,
+                SummarySection.CHOICES,
                 "Choices (" + alts.rows()
                     .size() + ")",
-                SECTION_HEADER_TEXT_X,
-                ly + SECTION_HEADER_TEXT_Y_OFF,
-                1.0f,
-                PlannhColors.ACCENT_CYAN2.getColor(),
-                false);
-            ly += SECTION_H;
+                PlannhColors.SECTION_CHOICE.getColor(),
+                PlannhColors.ACCENT_CYAN2.getColor());
+            if (!sectionOpen(SummarySection.CHOICES)) return ly + SECTION_END_PAD;
 
             // A heading per decision only when there is more than one: with a single question the
             // heading would just repeat the row directly under it.
@@ -815,19 +779,84 @@ public class FlowchartScreen extends ModularScreen {
             return ly + SECTION_END_PAD;
         }
 
-        private int drawSection(int ly, final int w, final String title, final List<Summary.Line<?>> items,
-            final int headerColor, final int titleColor, final int itemColor, final float cycleSecs,
-            final boolean isCycle) {
-            if (items.isEmpty()) return ly;
+        /**
+         * A clickable section heading. The fold marker doubles as the affordance: a section whose
+         * body is off still keeps its header, or there would be nothing left to click to get it
+         * back.
+         */
+        private int drawSectionHeader(final int ly, final int w, final SummarySection section, final String title,
+            final int headerColor, final int titleColor) {
             GuiDraw.drawRect(SECTION_HEADER_X, ly, w - SECTION_HEADER_X * 2, SECTION_H, headerColor);
+            GuiDraw.drawText(title, SECTION_HEADER_TEXT_X, ly + SECTION_HEADER_TEXT_Y_OFF, 1.0f, titleColor, false);
             GuiDraw.drawText(
-                title + " (" + items.size() + ")",
-                SECTION_HEADER_TEXT_X,
+                sectionOpen(section) ? "\u2212" : "+",
+                w - SECTION_TOGGLE_X_OFF,
                 ly + SECTION_HEADER_TEXT_Y_OFF,
                 1.0f,
                 titleColor,
                 false);
-            ly += SECTION_H;
+            headerRows.put(section, new int[] { ly, ly + SECTION_H });
+            return ly + SECTION_H;
+        }
+
+        /** Per-node operation counts and the run totals, folded away by default. */
+        private int drawOperations(int ly, final int w, final BalanceResult br, final boolean isCycle) {
+            if (operationLineCount(br) == 0) return ly;
+            ly = drawSectionHeader(
+                ly,
+                w,
+                SummarySection.OPERATIONS,
+                "Operations",
+                PlannhColors.SECTION_OPS.getColor(),
+                PlannhColors.ACCENT_BLUE.getColor());
+            if (!sectionOpen(SummarySection.OPERATIONS)) return ly + SECTION_END_PAD;
+
+            for (final Node node : graph().getNodes()) {
+                final NodeBalance nb = br.nodeBalances()
+                    .get(node.id);
+                if (nb == null || nb.operations() <= 0) continue;
+                GuiDraw.drawText(
+                    "\u00d7" + GuiHelper.formatCount(nb.operations()) + "  " + node.machineName,
+                    ITEM_TEXT_X,
+                    ly,
+                    0.8f,
+                    PlannhColors.TEXT_LIGHT.getColor(),
+                    false);
+                ly += LINE_H;
+            }
+
+            final StringBuilder totals = new StringBuilder();
+            if (br.totalOperations() > 0) totals.append("Ops: ")
+                .append(GuiHelper.formatCount(br.totalOperations()));
+            if (br.totalDurationTicks() > 0) {
+                final float sec = (float) br.totalDurationTicks() / GuiHelper.TICKS_PER_SECOND;
+                if (!totals.isEmpty()) totals.append("  ");
+                if (isCycle) {
+                    totals.append("Time: ")
+                        .append(br.totalDurationTicks())
+                        .append("t");
+                    if (sec > 0) totals.append(" (")
+                        .append(String.format("%.1f", sec))
+                        .append("s/cycle)");
+                } else {
+                    totals.append("Cycle: ")
+                        .append(String.format("%.1f", sec))
+                        .append("s");
+                }
+            }
+            if (!totals.isEmpty()) {
+                GuiDraw.drawText(totals.toString(), ITEM_TEXT_X, ly, 0.8f, PlannhColors.ACCENT_BLUE.getColor(), false);
+                ly += LINE_H;
+            }
+            return ly + SECTION_END_PAD;
+        }
+
+        private int drawSection(int ly, final int w, final SummarySection section, final String title,
+            final List<Summary.Line<?>> items, final int headerColor, final int titleColor, final int itemColor,
+            final float cycleSecs, final boolean isCycle) {
+            if (items.isEmpty()) return ly;
+            ly = drawSectionHeader(ly, w, section, title + " (" + items.size() + ")", headerColor, titleColor);
+            if (!sectionOpen(section)) return ly + SECTION_END_PAD;
             for (final var item : items) {
                 final String text = item.displayAmount(isCycle ? item.amount() : item.amount() / cycleSecs)
                     + (isCycle ? " x " : "/s ")
@@ -857,6 +886,16 @@ public class FlowchartScreen extends ModularScreen {
 
             final Graph g0 = graph();
             final BalanceResult br0 = g0.balance();
+
+            for (final var header : headerRows.entrySet()) {
+                if (my < header.getValue()[0] || my >= header.getValue()[1]) continue;
+                final var folded = PlanAPI.getSlotSet().collapsedSummarySections;
+                if (!folded.add(header.getKey())) folded.remove(header.getKey());
+                PlanAPI.save();
+                size(WIDTH, computeHeight(displayedSummary(g0.summary(), br0), br0));
+                return Result.SUCCESS;
+            }
+
             if (choicesOffered(br0)) {
                 final List<BalanceView.Choice> options = g0.choices()
                     .rows();

--- a/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
+++ b/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
@@ -189,7 +189,10 @@ public class FlowchartScreen extends ModularScreen {
                                     return true;
                                 }))
                         .child(
-                            IKey.str("Slot " + (PlanAPI.getSlotSet().activeSlot + 1))
+                            // Dynamic, and read off the live SlotSet: built as a plain string this
+                            // label kept whichever slot was active when the screen opened, so the
+                            // arrows moved the canvas underneath a number that never followed.
+                            IKey.dynamicKey(() -> IKey.str(slotLabel()))
                                 .asWidget()
                                 .color(Color.WHITE.main))
                         .child(
@@ -362,6 +365,13 @@ public class FlowchartScreen extends ModularScreen {
 
     // ── Slot bar helpers ──
 
+    /** "Slot (4/8)": which chart is on screen, and how many there are to page through. */
+    private static String slotLabel() {
+        final SlotSet set = PlanAPI.getSlotSet();
+        final int count = Math.max(1, set.slots.size());
+        return "Slot (" + Math.min(count, set.activeSlot + 1) + "/" + count + ")";
+    }
+
     private static void shiftSlot(final CanvasWidget canvas, final int dir) {
         final SlotSet set = PlanAPI.getSlotSet();
         if (set.slots.size() <= 1) return;
@@ -496,7 +506,9 @@ public class FlowchartScreen extends ModularScreen {
 
         /** A null section is one that does not fold, and an unfoldable section is always open. */
         private boolean sectionOpen(@Nullable final SummarySection section) {
-            return section == null || !PlanAPI.getSlotSet().collapsedSummarySections.contains(section);
+            return section == null || !PlanAPI.getSlotSet()
+                .getActiveSummaryFolds()
+                .contains(section);
         }
 
         /** Header plus, when the section is open, one line per body row. */
@@ -625,16 +637,28 @@ public class FlowchartScreen extends ModularScreen {
         }
 
         /**
-         * The heading takes the colour of the loudest message under it: folded by default, the bar
-         * is all the user sees, so it has to carry whether anything down there is on fire.
+         * The loudest thing the solver said, which is what the heading has to carry: an alarming
+         * bar over three informational notes cries wolf, and the next real warning reads as more
+         * of the same.
          */
-        private static int loudestColor(final BalanceResult br) {
+        private static AutoBalancer.Severity loudest(final BalanceResult br) {
             AutoBalancer.Severity worst = AutoBalancer.Severity.INFO;
             for (final String note : br.notes()) {
                 final AutoBalancer.Severity severity = AutoBalancer.Severity.of(note);
                 if (severity.ordinal() < worst.ordinal()) worst = severity;
             }
-            return severityColor(worst);
+            return worst;
+        }
+
+        /** Section bar behind the messages heading: the alarming one only when something is wrong. */
+        private static int loudestHeaderColor(final AutoBalancer.Severity worst) {
+            return worst == AutoBalancer.Severity.INFO ? PlannhColors.SECTION_OPS.getColor()
+                : PlannhColors.SECTION_WARN.getColor();
+        }
+
+        /** Heading text, which unlike a message line has to stay legible against its own bar. */
+        private static int loudestTitleColor(final AutoBalancer.Severity worst) {
+            return worst == AutoBalancer.Severity.INFO ? PlannhColors.ACCENT_BLUE.getColor() : severityColor(worst);
         }
 
         @Override
@@ -711,14 +735,15 @@ public class FlowchartScreen extends ModularScreen {
 
             wrapNotes(br);
             if (!wrappedMessages.isEmpty()) {
+                final AutoBalancer.Severity worst = loudest(br);
                 ly = drawSectionHeader(
                     ly,
                     w,
                     SummarySection.MESSAGES,
                     "Solver Messages (" + br.notes()
                         .size() + ")",
-                    PlannhColors.SECTION_WARN.getColor(),
-                    loudestColor(br));
+                    loudestHeaderColor(worst),
+                    loudestTitleColor(worst));
                 if (sectionOpen(SummarySection.MESSAGES)) {
                     for (final MessageLine line : wrappedMessages) {
                         GuiDraw.drawText(line.text(), ITEM_TEXT_X, ly, NOTE_SCALE, line.color(), false);
@@ -936,7 +961,8 @@ public class FlowchartScreen extends ModularScreen {
 
             for (final var header : headerRows.entrySet()) {
                 if (my < header.getValue()[0] || my >= header.getValue()[1]) continue;
-                final var folded = PlanAPI.getSlotSet().collapsedSummarySections;
+                final var folded = PlanAPI.getSlotSet()
+                    .getActiveSummaryFolds();
                 if (!folded.add(header.getKey())) folded.remove(header.getKey());
                 PlanAPI.save();
                 size(WIDTH, computeHeight(displayedSummary(g0.summary(), br0), br0));

--- a/src/main/java/com/sbancuz/plannh/gui/PlannhColors.java
+++ b/src/main/java/com/sbancuz/plannh/gui/PlannhColors.java
@@ -39,7 +39,8 @@ public final class PlannhColors {
         SECTION_FLUID_OUT = C.argb("section_fluid_out",  "0x323C8CB4"),
         SECTION_FLUID_IN  = C.argb("section_fluid_in",   "0x323C64B4"),
         SECTION_OPS       = C.argb("section_ops",        "0x326478C8"),
-        SECTION_CHOICE    = C.argb("section_choice",     "0x3250A0A0");
+        SECTION_CHOICE    = C.argb("section_choice",     "0x3250A0A0"),
+        SECTION_WARN      = C.argb("section_warn",       "0x32C86450");
 
     // ── Text Colors (opaque) ──
     public static final ColorResource

--- a/src/test/java/com/sbancuz/plannh/BalanceViewTest.java
+++ b/src/test/java/com/sbancuz/plannh/BalanceViewTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
@@ -27,6 +28,15 @@ class BalanceViewTest {
     private static Graph chart(final String name) {
         return GtnhFlowLoader.load(name)
             .graph();
+    }
+
+    /** The one row matching {@code role}, failing rather than picking when there is not exactly one. */
+    private static Choice onlyRow(final List<Choice> rows, final Predicate<Choice> role) {
+        final List<Choice> matching = rows.stream()
+            .filter(role)
+            .toList();
+        assertEquals(1, matching.size(), () -> "expected exactly one such row, got " + matching);
+        return matching.get(0);
     }
 
     private static List<Boundary> of(final List<Boundary> flows, final Kind kind) {
@@ -146,33 +156,32 @@ class BalanceViewTest {
         // If that sentence ever stops reaching the panel, the tilt is invisible again.
         final List<Choice> rows = chart("mk1").choices()
             .rows();
-        assertEquals(
-            "imports instead of leaving a surplus",
-            rows.get(1)
-                .reason());
+        final Choice current = onlyRow(rows, Choice::active);
+        final Choice alternative = onlyRow(rows, r -> !r.active());
+        assertEquals("imports instead of leaving a surplus", alternative.reason());
         assertTrue(
-            rows.get(0)
-                .label()
+            current.label()
                 .startsWith("excess "),
-            () -> "default leaves a surplus: " + rows.get(0)
-                .label());
+            () -> "default leaves a surplus: " + current.label());
         assertTrue(
-            rows.get(1)
-                .label()
+            alternative.label()
                 .startsWith("add "),
-            () -> "alternative imports: " + rows.get(1)
-                .label());
+            () -> "alternative imports: " + alternative.label());
     }
 
     @Test
     void pickingAnAnswerChangesTheChartAndSticksAcrossASave() {
         final Graph graph = chart("symmetric_choice");
-        final Choice before = graph.choices()
-            .rows()
-            .get(0);
+        final Choice before = onlyRow(
+            graph.choices()
+                .rows(),
+            Choice::active);
         final Choice alternative = graph.choices()
             .rows()
-            .get(1);
+            .stream()
+            .filter(r -> !r.active())
+            .findFirst()
+            .orElseThrow();
         assertFalse(
             before.label()
                 .equals(alternative.label()),
@@ -211,16 +220,16 @@ class BalanceViewTest {
         // other imports, and one sentence cannot honestly describe both.
         assertEquals(
             "leaves more excess",
-            chart("excess_choice").choices()
-                .rows()
-                .get(1)
-                .reason());
+            onlyRow(
+                chart("excess_choice").choices()
+                    .rows(),
+                r -> !r.active()).reason());
         assertEquals(
             "imports more",
-            chart("loopGraph").choices()
-                .rows()
-                .get(1)
-                .reason());
+            onlyRow(
+                chart("loopGraph").choices()
+                    .rows(),
+                r -> !r.active()).reason());
     }
 
     @Test
@@ -248,9 +257,7 @@ class BalanceViewTest {
                     .filter(Choice::active)
                     .count());
             assertEquals(
-                group.rows()
-                    .get(0)
-                    .label(),
+                onlyRow(group.rows(), Choice::active).label(),
                 group.heading(),
                 "named by the answer in force");
         }
@@ -288,5 +295,47 @@ class BalanceViewTest {
                     .isEmpty(),
                 "an incomplete search has to explain itself");
         }
+    }
+
+    @Test
+    void alternativesReadAsAListOfAmounts_importsFirstThenAscending() {
+        // Under the answer in force, the rows are there to be compared against each other, so they
+        // sort like a list of amounts and not like the solver's preference order. Every chart with
+        // a choice, because an ordering that only holds on the chart it was written against is not
+        // an ordering.
+        for (final String name : List.of("symmetric_choice", "excess_choice", "mk1", "loopGraph", "two_decisions")) {
+            for (final BalanceView.Group group : chart(name).choices()
+                .groups()) {
+                boolean seenExcess = false;
+                double previous = Double.NEGATIVE_INFINITY;
+                for (final Choice row : group.rows()) {
+                    if (row.active()) continue; // sorted to the front, not into the amounts
+                    final boolean isImport = row.label()
+                        .startsWith("add ");
+                    if (isImport) {
+                        assertFalse(seenExcess, () -> name + " puts an import after a surplus: " + group.rows());
+                    } else if (!seenExcess) {
+                        seenExcess = true;
+                        previous = Double.NEGATIVE_INFINITY; // each block ascends on its own
+                    }
+                    final double rate = rateOf(row.label());
+                    assertTrue(
+                        rate >= previous,
+                        () -> name + " lists " + row.label() + " after a bigger amount: " + group.rows());
+                    previous = rate;
+                }
+            }
+        }
+    }
+
+    /**
+     * The number out of "add 33.33/s sulfuric acid", units and all stripped back off. Reads the
+     * label rather than the rate behind it on purpose - the order has to hold for what the panel
+     * shows - so a chart whose rows cross a unit boundary (mB against B) does not belong in the
+     * list above.
+     */
+    private static double rateOf(final String label) {
+        final String[] words = label.split(" ");
+        return Double.parseDouble(words[1].replaceAll("[^0-9.].*$", ""));
     }
 }

--- a/src/test/java/com/sbancuz/plannh/GroundTruthTest.java
+++ b/src/test/java/com/sbancuz/plannh/GroundTruthTest.java
@@ -2,6 +2,7 @@ package com.sbancuz.plannh;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
@@ -334,11 +335,42 @@ class GroundTruthTest {
             terminalRate(chart, s.terminalInputs(), "heavy naquadah fuel"),
             EPS,
             "fusion's heavy arrives via its free terminal");
-        assertTrue(
-            s.notes()
-                .stream()
-                .anyMatch(n -> n.contains(AutoBalancer.MISSING_EDGE)),
-            "the missing-edge diagnostic must fire, got notes: " + s.notes());
+        final String diagnostic = s.notes()
+            .stream()
+            .filter(n -> n.contains(AutoBalancer.MISSING_EDGE))
+            .findFirst()
+            .orElse(null);
+        assertNotNull(diagnostic, "the missing-edge diagnostic must fire, got notes: " + s.notes());
+        // The note is what the user acts on: it has to name the ingredient to point at, and carry
+        // the severity the panel colours it by. Informational, not a warning - importing something
+        // the chart also makes is how most charts are drawn.
+        assertEquals(
+            AutoBalancer.Severity.INFO,
+            AutoBalancer.Severity.of(diagnostic),
+            "raised as an observation: " + diagnostic);
+        assertTrue(diagnostic.contains("heavy naquadah fuel"), "names the ingredient: " + diagnostic);
+    }
+
+    @Test
+    void anIngredientOnTheFreeListRaisesNoWiringDiagnostic() {
+        // Same chart and same missing edge as above. Water is the real case - a chart pulling it
+        // from outside while some machine makes a little is not a mistake anyone wants told about -
+        // and the list is the pack's answer to which ingredients those are.
+        Config.setFreeIngredients("heavy naquadah fuel");
+        try {
+            final LoadedChart chart = GtnhFlowLoader.load("mk1_tiberium");
+            GtnhFlowLoader.removeEdgesInto(chart, chart.machine(0), 0);
+
+            final Solution s = solve(chart);
+
+            assertTrue(
+                s.notes()
+                    .stream()
+                    .noneMatch(n -> n.contains(AutoBalancer.MISSING_EDGE)),
+                "free ingredients are wired up by hand or not at all, got notes: " + s.notes());
+        } finally {
+            Config.setFreeIngredients(Config.DEFAULT_FREE_INGREDIENTS);
+        }
     }
 
     @Test

--- a/src/test/java/com/sbancuz/plannh/GroundTruthTest.java
+++ b/src/test/java/com/sbancuz/plannh/GroundTruthTest.java
@@ -369,7 +369,7 @@ class GroundTruthTest {
                     .noneMatch(n -> n.contains(AutoBalancer.MISSING_EDGE)),
                 "free ingredients are wired up by hand or not at all, got notes: " + s.notes());
         } finally {
-            Config.setFreeIngredients(Config.DEFAULT_FREE_INGREDIENTS);
+            Config.resetFreeIngredients();
         }
     }
 

--- a/src/test/java/com/sbancuz/plannh/SummaryOrderTest.java
+++ b/src/test/java/com/sbancuz/plannh/SummaryOrderTest.java
@@ -1,0 +1,77 @@
+package com.sbancuz.plannh;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.sbancuz.plannh.data.flowchart.Summary;
+import com.sbancuz.plannh.data.flowchart.Summary.Line;
+import com.sbancuz.plannh.harness.GtnhFlowLoader;
+
+/**
+ * The summary's two lists are read for opposite things - the headline product against the scarcest
+ * ingredient - so they sort opposite ways. They also used to come out of a hash map, which meant
+ * two draws of one unedited chart could disagree about the order.
+ */
+class SummaryOrderTest {
+
+    private static final List<String> CHARTS = List.of("mk1", "loopGraph", "excess_choice", "mk1_tiberium");
+
+    @Test
+    void outputsLeadWithTheBiggest() {
+        for (final String name : CHARTS) {
+            assertSorted(name, "outputs", summaryOf(name).outputs(), false);
+        }
+    }
+
+    @Test
+    void inputsLeadWithTheSmallest() {
+        for (final String name : CHARTS) {
+            assertSorted(name, "inputs", summaryOf(name).inputs(), true);
+        }
+    }
+
+    @Test
+    void oneUneditedChartSummarisesTheSameWayTwice() {
+        for (final String name : CHARTS) {
+            final var graph = GtnhFlowLoader.load(name)
+                .graph();
+            assertTrue(
+                names(
+                    graph.summary()
+                        .outputs()).equals(
+                            names(
+                                graph.summary()
+                                    .outputs())),
+                () -> name + " reordered its outputs between two reads");
+        }
+    }
+
+    private static Summary summaryOf(final String name) {
+        return GtnhFlowLoader.load(name)
+            .graph()
+            .summary();
+    }
+
+    private static List<String> names(final List<Line<?>> lines) {
+        return lines.stream()
+            .map(Line::displayName)
+            .toList();
+    }
+
+    private static void assertSorted(final String chart, final String what, final List<Line<?>> lines,
+        final boolean ascending) {
+        for (int i = 1; i < lines.size(); i++) {
+            final float previous = lines.get(i - 1)
+                .amount();
+            final float current = lines.get(i)
+                .amount();
+            final int index = i;
+            assertTrue(
+                ascending ? current >= previous : current <= previous,
+                () -> chart + " " + what + " out of order at row " + index + ": " + previous + " then " + current);
+        }
+    }
+}

--- a/src/test/java/com/sbancuz/plannh/SummarySectionPersistenceTest.java
+++ b/src/test/java/com/sbancuz/plannh/SummarySectionPersistenceTest.java
@@ -11,47 +11,63 @@ import com.sbancuz.plannh.data.flowchart.Serializer;
 import com.sbancuz.plannh.data.flowchart.SlotSet;
 import com.sbancuz.plannh.data.flowchart.Summary.SummarySection;
 
-/** Folded summary sections are a per-user preference: losing them re-expands panels every launch. */
+/**
+ * Folded summary sections are a per-chart preference: losing them re-expands panels every launch,
+ * and sharing them between slots followed one unfolded panel into every chart the user opened next.
+ */
 class SummarySectionPersistenceTest {
 
-    private static SlotSet oneSlot() {
+    private static SlotSet twoSlots() {
         final SlotSet set = new SlotSet();
         set.slots.add(new SlotSet.Slot("Slot 1", new Graph()));
+        set.slots.add(new SlotSet.Slot("Slot 2", new Graph()));
         return set;
     }
 
     @Test
-    void foldedSectionsSurviveEncodeDecode() {
-        final SlotSet set = oneSlot();
-        set.collapsedSummarySections.clear();
-        set.collapsedSummarySections.add(SummarySection.MESSAGES);
-        set.collapsedSummarySections.add(SummarySection.STATISTICS);
+    void foldedSectionsSurviveEncodeDecodePerSlot() {
+        final SlotSet set = twoSlots();
+        set.slots.get(0).collapsedSummarySections.clear();
+        set.slots.get(0).collapsedSummarySections.add(SummarySection.MESSAGES);
+        set.slots.get(1).collapsedSummarySections.clear();
 
         final SlotSet decoded = Serializer.decodeSlotSet(Serializer.encode(set));
 
-        assertEquals(EnumSet.of(SummarySection.MESSAGES, SummarySection.STATISTICS), decoded.collapsedSummarySections);
+        assertEquals(
+            EnumSet.of(SummarySection.MESSAGES),
+            decoded.slots.get(0).collapsedSummarySections,
+            "one chart's folds");
+        assertEquals(
+            EnumSet.noneOf(SummarySection.class),
+            decoded.slots.get(1).collapsedSummarySections,
+            "an explicitly empty set is 'everything open', not 'never saved'");
     }
 
-    /** An explicitly empty set is "everything open", not "never saved". */
     @Test
-    void allSectionsOpenSurvivesEncodeDecode() {
-        final SlotSet set = oneSlot();
-        set.collapsedSummarySections.clear();
+    void aNewSlotStartsFromTheDefaultsRatherThanTheLastChartsPanel() {
+        final SlotSet set = twoSlots();
+        set.slots.get(0).collapsedSummarySections.clear();
 
-        final SlotSet decoded = Serializer.decodeSlotSet(Serializer.encode(set));
+        set.slots.add(new SlotSet.Slot("Slot 3", new Graph()));
 
-        assertEquals(EnumSet.noneOf(SummarySection.class), decoded.collapsedSummarySections);
+        assertEquals(SlotSet.defaultSummaryFolds(), set.slots.get(2).collapsedSummarySections);
+        assertEquals(
+            SlotSet.defaultSummaryFolds(),
+            Serializer.decodeSlotSet(Serializer.encode(set)).slots.get(2).collapsedSummarySections,
+            "and still does after a round trip");
     }
 
-    /** Saves written before sections were foldable open like a fresh install. */
+    /** Saves written before folds were per slot open every chart the way a fresh install would. */
     @Test
     void savesWithoutTheKeyKeepTheDefaults() {
-        final String json = Serializer.encode(oneSlot())
-            .replace("\"summarySectionFolds\"", "\"unusedKey\"");
+        final String json = Serializer.encode(twoSlots())
+            .replace("\"sectionFolds\"", "\"unusedKey\"");
 
         final SlotSet decoded = Serializer.decodeSlotSet(json);
 
-        assertEquals(new SlotSet().collapsedSummarySections, decoded.collapsedSummarySections);
+        for (final SlotSet.Slot slot : decoded.slots) {
+            assertEquals(SlotSet.defaultSummaryFolds(), slot.collapsedSummarySections);
+        }
     }
 
     /**
@@ -60,9 +76,11 @@ class SummarySectionPersistenceTest {
      */
     @Test
     void aSectionTheSaveNeverHeardOfKeepsItsDefault() {
-        final SlotSet set = oneSlot();
-        set.collapsedSummarySections.clear();
-        set.collapsedSummarySections.add(SummarySection.STATISTICS);
+        final SlotSet set = twoSlots();
+        for (final SlotSet.Slot slot : set.slots) {
+            slot.collapsedSummarySections.clear();
+            slot.collapsedSummarySections.add(SummarySection.STATISTICS);
+        }
         final String json = Serializer.encode(set)
             .replace("\"" + SummarySection.HELP.name() + "\"", "\"SECTION_FROM_A_LATER_BUILD\"");
 
@@ -70,7 +88,15 @@ class SummarySectionPersistenceTest {
 
         assertEquals(
             EnumSet.of(SummarySection.STATISTICS, SummarySection.HELP),
-            decoded.collapsedSummarySections,
+            decoded.slots.get(0).collapsedSummarySections,
             "the unmentioned section keeps the default fold, the mentioned ones keep the save's");
+    }
+
+    /** Solver messages are the one section that starts open: a failed balance must not be silent. */
+    @Test
+    void solverMessagesStartOpen() {
+        assertEquals(
+            EnumSet.of(SummarySection.MACHINE_COUNTS, SummarySection.STATISTICS, SummarySection.HELP),
+            SlotSet.defaultSummaryFolds());
     }
 }

--- a/src/test/java/com/sbancuz/plannh/SummarySectionPersistenceTest.java
+++ b/src/test/java/com/sbancuz/plannh/SummarySectionPersistenceTest.java
@@ -1,0 +1,58 @@
+package com.sbancuz.plannh;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.EnumSet;
+
+import org.junit.jupiter.api.Test;
+
+import com.sbancuz.plannh.data.flowchart.Graph;
+import com.sbancuz.plannh.data.flowchart.Serializer;
+import com.sbancuz.plannh.data.flowchart.SlotSet;
+import com.sbancuz.plannh.data.flowchart.Summary.SummarySection;
+
+/** Folded summary sections are a per-user preference: losing them re-expands panels every launch. */
+class SummarySectionPersistenceTest {
+
+    private static SlotSet oneSlot() {
+        final SlotSet set = new SlotSet();
+        set.slots.add(new SlotSet.Slot("Slot 1", new Graph()));
+        return set;
+    }
+
+    @Test
+    void collapsedSectionsSurviveEncodeDecode() {
+        final SlotSet set = oneSlot();
+        set.collapsedSummarySections.clear();
+        set.collapsedSummarySections.add(SummarySection.NOTES);
+        set.collapsedSummarySections.add(SummarySection.PROPERTIES);
+
+        final SlotSet decoded = Serializer.decodeSlotSet(Serializer.encode(set));
+
+        assertEquals(
+            EnumSet.of(SummarySection.NOTES, SummarySection.PROPERTIES),
+            decoded.collapsedSummarySections);
+    }
+
+    /** An explicitly empty set is "everything open", not "never saved". */
+    @Test
+    void allSectionsOpenSurvivesEncodeDecode() {
+        final SlotSet set = oneSlot();
+        set.collapsedSummarySections.clear();
+
+        final SlotSet decoded = Serializer.decodeSlotSet(Serializer.encode(set));
+
+        assertEquals(EnumSet.noneOf(SummarySection.class), decoded.collapsedSummarySections);
+    }
+
+    /** Saves written before sections were foldable open like a fresh install. */
+    @Test
+    void savesWithoutTheKeyKeepTheDefault() {
+        final String json = Serializer.encode(oneSlot())
+            .replace("\"summaryCollapsedSections\"", "\"unusedKey\"");
+
+        final SlotSet decoded = Serializer.decodeSlotSet(json);
+
+        assertEquals(EnumSet.of(SummarySection.OPERATIONS), decoded.collapsedSummarySections);
+    }
+}

--- a/src/test/java/com/sbancuz/plannh/SummarySectionPersistenceTest.java
+++ b/src/test/java/com/sbancuz/plannh/SummarySectionPersistenceTest.java
@@ -21,17 +21,15 @@ class SummarySectionPersistenceTest {
     }
 
     @Test
-    void collapsedSectionsSurviveEncodeDecode() {
+    void foldedSectionsSurviveEncodeDecode() {
         final SlotSet set = oneSlot();
         set.collapsedSummarySections.clear();
-        set.collapsedSummarySections.add(SummarySection.NOTES);
-        set.collapsedSummarySections.add(SummarySection.PROPERTIES);
+        set.collapsedSummarySections.add(SummarySection.MESSAGES);
+        set.collapsedSummarySections.add(SummarySection.STATISTICS);
 
         final SlotSet decoded = Serializer.decodeSlotSet(Serializer.encode(set));
 
-        assertEquals(
-            EnumSet.of(SummarySection.NOTES, SummarySection.PROPERTIES),
-            decoded.collapsedSummarySections);
+        assertEquals(EnumSet.of(SummarySection.MESSAGES, SummarySection.STATISTICS), decoded.collapsedSummarySections);
     }
 
     /** An explicitly empty set is "everything open", not "never saved". */
@@ -47,12 +45,32 @@ class SummarySectionPersistenceTest {
 
     /** Saves written before sections were foldable open like a fresh install. */
     @Test
-    void savesWithoutTheKeyKeepTheDefault() {
+    void savesWithoutTheKeyKeepTheDefaults() {
         final String json = Serializer.encode(oneSlot())
-            .replace("\"summaryCollapsedSections\"", "\"unusedKey\"");
+            .replace("\"summarySectionFolds\"", "\"unusedKey\"");
 
         final SlotSet decoded = Serializer.decodeSlotSet(json);
 
-        assertEquals(EnumSet.of(SummarySection.OPERATIONS), decoded.collapsedSummarySections);
+        assertEquals(new SlotSet().collapsedSummarySections, decoded.collapsedSummarySections);
+    }
+
+    /**
+     * The reason the folds are stored section by section: a save written before a section existed
+     * must not drag that section open, or every new section arrives expanded for existing users.
+     */
+    @Test
+    void aSectionTheSaveNeverHeardOfKeepsItsDefault() {
+        final SlotSet set = oneSlot();
+        set.collapsedSummarySections.clear();
+        set.collapsedSummarySections.add(SummarySection.STATISTICS);
+        final String json = Serializer.encode(set)
+            .replace("\"" + SummarySection.HELP.name() + "\"", "\"SECTION_FROM_A_LATER_BUILD\"");
+
+        final SlotSet decoded = Serializer.decodeSlotSet(json);
+
+        assertEquals(
+            EnumSet.of(SummarySection.STATISTICS, SummarySection.HELP),
+            decoded.collapsedSummarySections,
+            "the unmentioned section keeps the default fold, the mentioned ones keep the save's");
     }
 }


### PR DESCRIPTION
# Comparison

| before | after |
| --- | --- |
| <img width="584" height="972" alt="image" src="https://github.com/user-attachments/assets/6bfdbf26-80c4-4b88-ab85-184e794b44fe" /> | <img width="567" height="555" alt="image" src="https://github.com/user-attachments/assets/ddffd288-142a-4e4d-91a5-542360c57a7c" /> |

New message wording / priority
<img width="420" height="132" alt="image" src="https://github.com/user-attachments/assets/be846a81-5949-4733-9428-aeae4e9a0514" />

# Changes

## Solver
- Categorize solver messages by priority level (INFO/WARN/ERROR)
- Add `solver.freeIngredients` - ingredients that result in no solver connection suggestions (for now, just Water)
- Fix message text that says "input 0" with the actual ingredient name

## Summary Node
- Rename sections
  - Operations -> Machine Counts
  - Properties -> Statistics
  - Notes -> Solver Messages
- Add new sections
  - Help
- Chronologically sort summary sections:
  - Choices
  - Inputs
  - Outputs
  - Machine Counts
  - Statistics
  - Solver Messages
  - Mode 
  - (separator)
  - Zoom
  - Help
- Collapsed by default
  - Machine Counts
  - Statistics
  - Help
- Sorting
  - Inputs: ascending (tie break by name)
  - Outputs: descending (tie break by name)
  - Choices: current answer first, then sources before sinks, then ascending quantity, then ChoiceKey
  - Machine Counts: descending
- Color "Solver Messages" header by the priority level of the solver message (Blue/Amber/Red)
- Make SECTION_OPS title readable
- Allow toggling Machine Counts entirely off in config
- Clean up / correct stale Help messages (MMB pan, double click open NEI)

## Other GUI Fixes
- Make slot selector number actually update (e.g. "Slot (4/8)")