### PR TITLE
Versioned injection

### DIFF
--- a/src/main/java/com/sbancuz/plannh/annotation/Versioned.java
+++ b/src/main/java/com/sbancuz/plannh/annotation/Versioned.java
@@ -1,12 +1,41 @@
 package com.sbancuz.plannh.annotation;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Declares that a constant PlanNH holds is really a dependency's number, and should be read from that
+ * dependency at startup instead of trusted.
+ *
+ * <p>
+ * A mod's balance changes without asking PlanNH, and a copied number then reports a machine that no
+ * longer exists. The copy stays in the source as the value to use when the dependency is absent or has
+ * moved on, and {@link VersionedInjector} overwrites it during preInit with whatever the installed jar
+ * actually says.
+ *
+ * <h2>Rules the injector enforces</h2>
+ *
+ * <ul>
+ * <li>A mirror field must <b>not be final</b>. A {@code static final} field with a literal initializer
+ * is a JLS 4.12.4 constant variable: javac folds its value into every use site, so overwriting the
+ * field afterwards changes a field nobody reads. This is not theoretical - it is what the first
+ * version of this annotation did, silently, for every scalar it was pointed at.
+ * <li>{@link Class#value()} must name the dependency's class in full. There is no deriving it from
+ * the mirror's own name.
+ * </ul>
+ */
 public @interface Versioned {
 
+    /**
+     * Marks a class that holds mirrors of one mod's constants.
+     *
+     * @param sinceVersion the earliest version of the mod expected to have these. A field that cannot
+     *                     be read is reported only when the installed mod is this version or newer,
+     *                     because on an older one its absence is the whole reason for the fallback.
+     */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.TYPE)
     @interface Mod {
@@ -16,6 +45,13 @@ public @interface Versioned {
         String sinceVersion();
     }
 
+    /**
+     * Marks a nested class whose fields mirror the static fields of one class in the dependency.
+     *
+     * @param value the dependency class's fully qualified name. Preferred over {@link #clazz()} for an
+     *              optional mod: naming it as a string costs nothing when the mod is absent, whereas a
+     *              class literal is a real reference the annotation cannot always resolve.
+     */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.TYPE)
     @SuppressWarnings("FieldMayBeFinal")
@@ -30,13 +66,31 @@ public @interface Versioned {
         String sinceVersion() default "";
     }
 
+    /**
+     * Names the field in the dependency this mirror reads, when the two names differ.
+     *
+     * <p>
+     * Repeatable, which is how one PlanNH constant follows a field the mod renamed: give one
+     * {@code @Constant} per name the field has had and the first that resolves wins. Order them
+     * newest-first, since that is the version most players are on and the one worth finding without
+     * a failed lookup in front of it.
+     */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.FIELD)
+    @Repeatable(Versioned.Constants.class)
     @SuppressWarnings("FieldMayBeFinal")
     @interface Constant {
 
         String value() default "";
 
         String sinceVersion() default "";
+    }
+
+    /** Holder for repeated {@link Constant}s; never written by hand. */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface Constants {
+
+        Constant[] value();
     }
 }

--- a/src/main/java/com/sbancuz/plannh/annotation/Versioned.java
+++ b/src/main/java/com/sbancuz/plannh/annotation/Versioned.java
@@ -16,16 +16,11 @@ import java.lang.annotation.Target;
  * moved on, and {@link VersionedInjector} overwrites it during preInit with whatever the installed jar
  * actually says.
  *
- * <h2>Rules the injector enforces</h2>
- *
- * <ul>
- * <li>A mirror field must <b>not be final</b>. A {@code static final} field with a literal initializer
- * is a JLS 4.12.4 constant variable: javac folds its value into every use site, so overwriting the
- * field afterwards changes a field nobody reads. This is not theoretical - it is what the first
- * version of this annotation did, silently, for every scalar it was pointed at.
- * <li>{@link Class#value()} must name the dependency's class in full. There is no deriving it from
- * the mirror's own name.
- * </ul>
+ * <p>
+ * Two things a mirror has to get right. A field must not be final: a {@code static final} with a
+ * literal initializer is a JLS 4.12.4 constant variable, so javac folds its value into every use site
+ * and overwriting the field reaches nobody. And {@link Class#value()} must name the dependency's class
+ * in full, since nothing derives it from the mirror's own name.
  */
 public @interface Versioned {
 

--- a/src/main/java/com/sbancuz/plannh/annotation/VersionedInjector.java
+++ b/src/main/java/com/sbancuz/plannh/annotation/VersionedInjector.java
@@ -1,7 +1,13 @@
 package com.sbancuz.plannh.annotation;
 
 import java.lang.reflect.Field;
-import java.util.Set;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
 
 import com.sbancuz.plannh.PlanNH;
 
@@ -9,118 +15,235 @@ import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.ModContainer;
 import cpw.mods.fml.common.discovery.ASMDataTable;
 import cpw.mods.fml.common.versioning.DefaultArtifactVersion;
-import sun.misc.Unsafe;
 
-public class VersionedInjector {
+/**
+ * Copies the dependency's own numbers over PlanNH's fallbacks at preInit. See {@link Versioned} for
+ * what the annotations mean and what a mirror field has to look like.
+ *
+ * <p>
+ * Everything here fails soft and says so. A mod that is absent, a class that moved, a field that was
+ * renamed - each leaves the fallback in place, because a planner quoting a slightly stale number is
+ * worth more than one that will not load. The one thing it will not do is fail quietly: a lookup that
+ * misses on a mod new enough to have had the field is logged, since that is drift rather than an old
+ * pack.
+ */
+public final class VersionedInjector {
 
-    public static void injectAll(ASMDataTable asmData) {
-        Set<ASMDataTable.ASMData> mods = asmData.getAll(Versioned.Mod.class.getName());
-        for (ASMDataTable.ASMData data : mods) {
+    private VersionedInjector() {}
+
+    public static void injectAll(final ASMDataTable asmData) {
+        injectAll(asmData, VersionedInjector::modPresent);
+    }
+
+    /**
+     * As above, against a stated idea of which mods are installed.
+     *
+     * <p>
+     * Package-private for the test that covers the skip: outside a running game there is no Forge to
+     * ask, so {@link #modPresent} answers "yes" to everything and the branch that matters here -
+     * leaving an absent mod's provider unloaded - is unreachable any other way.
+     */
+    static void injectAll(final ASMDataTable asmData, final Predicate<String> installed) {
+        for (final ASMDataTable.ASMData data : asmData.getAll(Versioned.Mod.class.getName())) {
+            // The mod id is read out of the ASM table rather than off the loaded class, because
+            // loading a provider is exactly what has to be avoided when its mod is missing: the class
+            // names the mod's types throughout, and resolving them is what would fail.
+            final Object declaredModId = data.getAnnotationInfo()
+                .get("modId");
+            if (declaredModId != null && !installed.test(declaredModId.toString())) continue;
+
             try {
-                Class<?> modClass = Class.forName(data.getClassName());
-                Versioned.Mod modAnn = modClass.getAnnotation(Versioned.Mod.class);
-                if (modAnn != null) {
-                    processModClass(modClass, modAnn.modId(), modAnn.sinceVersion());
-                }
-            } catch (ReflectiveOperationException e) {
-                PlanNH.LOG.error("Failed to process @Versioned.Mod on {}", data.getClassName(), e);
+                inject(Class.forName(data.getClassName()));
+            } catch (final ReflectiveOperationException | LinkageError e) {
+                PlanNH.LOG.error("PlanNH: cannot read versioned constants from {}", data.getClassName(), e);
             }
         }
     }
 
-    private static void processModClass(Class<?> modClass, String modId, String sinceVersion) {
-        for (Class<?> inner : modClass.getDeclaredClasses()) {
-            Versioned.Class classAnn = inner.getAnnotation(Versioned.Class.class);
-            if (classAnn == null) continue;
+    /**
+     * Fills in every mirror on one holder. Separate from the ASM sweep so it can be driven directly,
+     * which is the only way to check the mechanism without a mod installed to check it against.
+     */
+    public static void inject(final Class<?> holder) {
+        final Versioned.Mod mod = holder.getAnnotation(Versioned.Mod.class);
+        if (mod == null) return;
 
-            String resolvedModId = classAnn.modId()
-                .isEmpty() ? modId : classAnn.modId();
-            String resolvedSince = classAnn.sinceVersion()
-                .isEmpty() ? sinceVersion : classAnn.sinceVersion();
-            Class<?> target = resolveTargetClass(classAnn, inner, resolvedModId);
-            if (target == null) continue;
+        for (final Class<?> mirror : holder.getDeclaredClasses()) {
+            final Versioned.Class declared = mirror.getAnnotation(Versioned.Class.class);
+            if (declared == null) continue;
 
-            for (Field field : inner.getDeclaredFields()) {
-                Versioned.Constant constAnn = field.getAnnotation(Versioned.Constant.class);
-                String fieldName = (constAnn != null && !constAnn.value()
-                    .isEmpty()) ? constAnn.value() : field.getName();
-                String fieldSince = (constAnn != null && !constAnn.sinceVersion()
-                    .isEmpty()) ? constAnn.sinceVersion() : resolvedSince;
-                injectField(field, target, resolvedModId, fieldSince, fieldName);
+            final String modId = declared.modId()
+                .isEmpty() ? mod.modId() : declared.modId();
+            final String since = declared.sinceVersion()
+                .isEmpty() ? mod.sinceVersion() : declared.sinceVersion();
+
+            final Class<?> source = resolveSource(declared);
+            if (source == null) {
+                // Not "the mod is old": the class is named in full, so failing to find it means the
+                // dependency moved it, and every field under this mirror is now a guess.
+                warnIfNewEnough(modId, since, () -> "class " + named(declared) + " is gone");
+                continue;
+            }
+
+            for (final Field target : mirror.getDeclaredFields()) {
+                injectField(target, source, modId, since);
             }
         }
     }
 
-    private static Class<?> resolveTargetClass(Versioned.Class ann, Class<?> inner, String modId) {
-        if (ann.clazz() != void.class) return ann.clazz();
+    private static void injectField(final Field target, final Class<?> source, final String modId,
+        final String mirrorSince) {
+        if (target.isSynthetic()) return;
+        if (!Modifier.isStatic(target.getModifiers())) return;
 
-        String className = !ann.value()
-            .isEmpty() ? ann.value() : inner.getSimpleName();
+        // A final mirror is the failure this class was rewritten to stop. javac folds a constant
+        // variable into its use sites, so the write below would land somewhere nothing reads.
+        if (Modifier.isFinal(target.getModifiers())) {
+            PlanNH.LOG.error(
+                "PlanNH: {}.{} is final, so its value is compiled into every use site and cannot be "
+                    + "read from {}. Drop the final.",
+                target.getDeclaringClass()
+                    .getSimpleName(),
+                target.getName(),
+                modId);
+            return;
+        }
 
-        try {
-            return Class.forName(className);
-        } catch (ClassNotFoundException ignored) {}
+        final List<Candidate> candidates = candidatesFor(target, mirrorSince);
+        for (final Candidate candidate : candidates) {
+            final Object value = read(source, candidate.name());
+            if (value == null) continue;
 
-        return null;
-    }
-
-    private static Unsafe UNSAFE;
-
-    private static Unsafe unsafe() {
-        if (UNSAFE == null) {
             try {
-                Field f = Unsafe.class.getDeclaredField("theUnsafe");
-                f.setAccessible(true);
-                UNSAFE = (Unsafe) f.get(null);
-            } catch (ReflectiveOperationException e) {
-                throw new RuntimeException(e);
+                target.setAccessible(true);
+                target.set(null, value);
+                return;
+            } catch (final ReflectiveOperationException | IllegalArgumentException e) {
+                PlanNH.LOG.error(
+                    "PlanNH: {}.{} does not accept {}.{}",
+                    target.getDeclaringClass()
+                        .getSimpleName(),
+                    target.getName(),
+                    source.getSimpleName(),
+                    candidate.name(),
+                    e);
+                return;
             }
         }
-        return UNSAFE;
+
+        // Against the earliest version any of the names was expected under: from that release onwards
+        // one of them should have resolved, so nothing resolving is drift rather than an old pack.
+        warnIfNewEnough(modId, earliest(candidates), () -> source.getName() + " has no " + describe(candidates));
     }
 
-    private static void injectField(Field field, Class<?> sourceClass, String modId, String sinceVersion,
-        String fieldName) {
+    /** One name the dependency might know a constant by, and the release it was expected from. */
+    private record Candidate(String name, String since) {}
+
+    /**
+     * The names to try, in declaration order, which the annotation asks to be newest-first. A field
+     * with no {@code @Constant} mirrors the name it already has - the common case, and why the
+     * annotation is optional.
+     */
+    private static List<Candidate> candidatesFor(final Field target, final String mirrorSince) {
+        final Versioned.Constant[] declared = target.getAnnotationsByType(Versioned.Constant.class);
+        if (declared.length == 0) return List.of(new Candidate(target.getName(), mirrorSince));
+
+        final List<Candidate> candidates = new ArrayList<>();
+        for (final Versioned.Constant constant : declared) {
+            candidates.add(
+                new Candidate(
+                    constant.value()
+                        .isEmpty() ? target.getName() : constant.value(),
+                    constant.sinceVersion()
+                        .isEmpty() ? mirrorSince : constant.sinceVersion()));
+        }
+        return candidates;
+    }
+
+    private static String earliest(final List<Candidate> candidates) {
+        return candidates.stream()
+            .map(Candidate::since)
+            .min(Comparator.comparing(DefaultArtifactVersion::new))
+            .orElseThrow();
+    }
+
+    private static String describe(final List<Candidate> candidates) {
+        if (candidates.size() == 1) return "field " + candidates.getFirst()
+            .name();
+        return "field named any of " + candidates.stream()
+            .map(Candidate::name)
+            .toList();
+    }
+
+    /** The dependency's value, or null when it has no such static field to read. */
+    @Nullable
+    private static Object read(final Class<?> source, final String name) {
         try {
-            Field sourceField = sourceClass.getDeclaredField(fieldName);
-            Object value = sourceField.get(null);
-            Class<?> type = field.getType();
-            long offset = unsafe().staticFieldOffset(field);
-            if (type == int.class) {
-                unsafe().putInt(field.getDeclaringClass(), offset, (int) value);
-            } else if (type == long.class) {
-                unsafe().putLong(field.getDeclaringClass(), offset, (long) value);
-            } else if (type == double.class) {
-                unsafe().putDouble(field.getDeclaringClass(), offset, (double) value);
-            } else if (type == float.class) {
-                unsafe().putFloat(field.getDeclaringClass(), offset, (float) value);
-            } else if (type == boolean.class) {
-                unsafe().putBoolean(field.getDeclaringClass(), offset, (boolean) value);
-            } else {
-                unsafe().putObject(field.getDeclaringClass(), offset, value);
-            }
-        } catch (ReflectiveOperationException | LinkageError e) {
-            warnIfUnexpected(sourceClass, modId, sinceVersion, fieldName);
+            final Field field = source.getDeclaredField(name);
+            if (!Modifier.isStatic(field.getModifiers())) return null;
+            field.setAccessible(true);
+            return field.get(null);
+        } catch (final ReflectiveOperationException | RuntimeException | LinkageError absent) {
+            return null;
         }
     }
 
-    private static void warnIfUnexpected(Class<?> sourceClass, String modId, String sinceVersion, String fieldName) {
-        ModContainer container = Loader.instance()
-            .getIndexedModList()
-            .get(modId);
+    @Nullable
+    private static Class<?> resolveSource(final Versioned.Class declared) {
+        if (declared.clazz() != void.class) return declared.clazz();
+        if (declared.value()
+            .isEmpty()) {
+            PlanNH.LOG.error("PlanNH: @Versioned.Class needs the dependency class named in full");
+            return null;
+        }
+        try {
+            return Class.forName(declared.value());
+        } catch (final ClassNotFoundException | LinkageError absent) {
+            return null;
+        }
+    }
+
+    private static String named(final Versioned.Class declared) {
+        return declared.clazz() != void.class ? declared.clazz()
+            .getName() : declared.value();
+    }
+
+    /**
+     * Reports a miss only against a mod new enough to have had what was looked for. On an older one
+     * the fallback is the right answer and saying so every launch would train people to ignore it.
+     */
+    private static void warnIfNewEnough(final String modId, final String sinceVersion,
+        final java.util.function.Supplier<String> what) {
+        final ModContainer container = installed(modId);
         if (container == null) return;
 
-        DefaultArtifactVersion current = new DefaultArtifactVersion(container.getVersion());
-        DefaultArtifactVersion since = new DefaultArtifactVersion(sinceVersion);
+        if (new DefaultArtifactVersion(container.getVersion()).compareTo(new DefaultArtifactVersion(sinceVersion)) < 0)
+            return;
 
-        if (current.compareTo(since) >= 0) {
-            PlanNH.LOG.warn(
-                "Versioned field {}.{} missing on {} {} (expected present since {}) \u2014 falling back to hardcoded default",
-                sourceClass.getName(),
-                fieldName,
-                modId,
-                container.getVersion(),
-                sinceVersion);
+        PlanNH.LOG.warn(
+            "PlanNH: {} {} - {}. Falling back to the value PlanNH was written against, which may be stale.",
+            modId,
+            container.getVersion(),
+            what.get());
+    }
+
+    /** Null when the mod is absent, or when there is no Forge to ask - a test driving this directly. */
+    @Nullable
+    private static ModContainer installed(final String modId) {
+        try {
+            return Loader.instance()
+                .getIndexedModList()
+                .get(modId);
+        } catch (final RuntimeException | LinkageError outsideForge) {
+            return null;
+        }
+    }
+
+    private static boolean modPresent(final String modId) {
+        try {
+            return Loader.isModLoaded(modId);
+        } catch (final RuntimeException | LinkageError outsideForge) {
+            return true;
         }
     }
 }

--- a/src/main/java/com/sbancuz/plannh/annotation/VersionedInjector.java
+++ b/src/main/java/com/sbancuz/plannh/annotation/VersionedInjector.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
@@ -35,15 +36,8 @@ public final class VersionedInjector {
         injectAll(asmData, VersionedInjector::modPresent);
     }
 
-    /**
-     * As above, against a stated idea of which mods are installed.
-     *
-     * <p>
-     * Package-private for the test that covers the skip: outside a running game there is no Forge to
-     * ask, so {@link #modPresent} answers "yes" to everything and the branch that matters here -
-     * leaving an absent mod's provider unloaded - is unreachable any other way.
-     */
-    static void injectAll(final ASMDataTable asmData, final Predicate<String> installed) {
+    /** As above, against a stated set of installed mods rather than the one Forge reports. */
+    public static void injectAll(final ASMDataTable asmData, final Predicate<String> installed) {
         for (final ASMDataTable.ASMData data : asmData.getAll(Versioned.Mod.class.getName())) {
             // The mod id is read out of the ASM table rather than off the loaded class, because
             // loading a provider is exactly what has to be avoided when its mod is missing: the class
@@ -54,7 +48,10 @@ public final class VersionedInjector {
 
             try {
                 inject(Class.forName(data.getClassName()));
-            } catch (final ReflectiveOperationException | LinkageError e) {
+            } catch (final ReflectiveOperationException | RuntimeException | LinkageError e) {
+                // RuntimeException covers a mirror declared with clazz() rather than value(): reading
+                // a Class-valued annotation element whose class is absent throws TypeNotPresentException,
+                // and one unusable mirror must not be the thing that stops the game loading.
                 PlanNH.LOG.error("PlanNH: cannot read versioned constants from {}", data.getClassName(), e);
             }
         }
@@ -81,7 +78,11 @@ public final class VersionedInjector {
             if (source == null) {
                 // Not "the mod is old": the class is named in full, so failing to find it means the
                 // dependency moved it, and every field under this mirror is now a guess.
-                warnIfNewEnough(modId, since, () -> "class " + named(declared) + " is gone");
+                warnIfNewEnough(
+                    modId,
+                    since,
+                    () -> "class " + (declared.clazz() != void.class ? declared.clazz()
+                        .getName() : declared.value()) + " is gone");
                 continue;
             }
 
@@ -96,8 +97,8 @@ public final class VersionedInjector {
         if (target.isSynthetic()) return;
         if (!Modifier.isStatic(target.getModifiers())) return;
 
-        // A final mirror is the failure this class was rewritten to stop. javac folds a constant
-        // variable into its use sites, so the write below would land somewhere nothing reads.
+        // javac folds a constant variable into its use sites, so writing this field would land
+        // somewhere nothing reads.
         if (Modifier.isFinal(target.getModifiers())) {
             PlanNH.LOG.error(
                 "PlanNH: {}.{} is final, so its value is compiled into every use site and cannot be "
@@ -203,17 +204,11 @@ public final class VersionedInjector {
         }
     }
 
-    private static String named(final Versioned.Class declared) {
-        return declared.clazz() != void.class ? declared.clazz()
-            .getName() : declared.value();
-    }
-
     /**
      * Reports a miss only against a mod new enough to have had what was looked for. On an older one
      * the fallback is the right answer and saying so every launch would train people to ignore it.
      */
-    private static void warnIfNewEnough(final String modId, final String sinceVersion,
-        final java.util.function.Supplier<String> what) {
+    private static void warnIfNewEnough(final String modId, final String sinceVersion, final Supplier<String> what) {
         final ModContainer container = installed(modId);
         if (container == null) return;
 

--- a/src/main/java/com/sbancuz/plannh/data/provider/AE2Provider.java
+++ b/src/main/java/com/sbancuz/plannh/data/provider/AE2Provider.java
@@ -31,20 +31,24 @@ import codechicken.nei.recipe.IRecipeHandler;
 @Versioned.Mod(modId = Compat.IDs.AE2, sinceVersion = "rv3-beta-1017-GTNH")
 public final class AE2Provider implements PropertyProvider {
 
-    @Versioned.Class
+    /**
+     * Values read off AE2 at startup; what is written here is only what to use when AE2 is absent or
+     * predates the field. Not final, deliberately - see {@link Versioned}.
+     */
+    @Versioned.Class("appeng.tile.misc.TileInscriber")
     public static class TileInscriber {
 
-        public static final int MAX_PROCESSING_TIME = 100;
-        public static final int BASE_POWER_PER_TICK = 10;
-        public static final int BASE_SPEED = 1;
+        public static int MAX_PROCESSING_TIME = 100;
+        public static int BASE_POWER_PER_TICK = 10;
+        public static int BASE_SPEED = 1;
     }
 
-    @Versioned.Class
+    @Versioned.Class("appeng.tile.crafting.TileMolecularAssembler")
     public static class TileMolecularAssembler {
 
-        public static final int MAX_PROCESSING_TIME = 100;
-        public static final int[] SPEED = { 10, 13, 17, 20, 25, 50 };
-        public static final double[] ACCELERATION_TAX = { 1.0, 1.3, 1.7, 2.0, 2.5, 5.0 };
+        public static int MAX_PROCESSING_TIME = 100;
+        public static int[] SPEED = { 10, 13, 17, 20, 25, 50 };
+        public static double[] ACCELERATION_TAX = { 1.0, 1.3, 1.7, 2.0, 2.5, 5.0 };
     }
 
     @Override

--- a/src/test/java/com/sbancuz/plannh/VersionedAsmSweepTest.java
+++ b/src/test/java/com/sbancuz/plannh/VersionedAsmSweepTest.java
@@ -1,4 +1,4 @@
-package com.sbancuz.plannh.annotation;
+package com.sbancuz.plannh;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -8,16 +8,18 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.sbancuz.plannh.annotation.Versioned;
+import com.sbancuz.plannh.annotation.VersionedInjector;
+
 import cpw.mods.fml.common.discovery.ASMDataTable;
 
 /**
  * The sweep over FML's annotation table, which is how the injector is actually entered in a game.
  *
  * <p>
- * The branch worth pinning is the one that skips a provider whose mod is absent. It exists because the
- * old sweep called {@code Class.forName} on every annotated provider unconditionally: a provider names
- * its mod's types throughout, so on a pack without that mod the load is what fails - and the catch
- * clause did not cover {@code LinkageError}, so it would have taken preInit with it.
+ * The branch worth pinning is the one that skips a provider whose mod is absent. A provider names its
+ * mod's types throughout, so on a pack without that mod loading it is what fails, and it fails with a
+ * {@code LinkageError} during preInit.
  *
  * <p>
  * A holder records in a static initializer that it was loaded at all, and the tests read that. Class
@@ -42,7 +44,7 @@ class VersionedAsmSweepTest {
         static int SPEED = 42;
     }
 
-    private static final String DEPENDENCY = "com.sbancuz.plannh.annotation.VersionedAsmSweepTest$Dependency";
+    private static final String DEPENDENCY = "com.sbancuz.plannh.VersionedAsmSweepTest$Dependency";
 
     @Versioned.Mod(modId = "presentmod", sinceVersion = "1.0")
     static final class PresentHolder {

--- a/src/test/java/com/sbancuz/plannh/VersionedInjectionTest.java
+++ b/src/test/java/com/sbancuz/plannh/VersionedInjectionTest.java
@@ -1,0 +1,212 @@
+package com.sbancuz.plannh;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sbancuz.plannh.annotation.Versioned;
+import com.sbancuz.plannh.annotation.VersionedInjector;
+
+/**
+ * The annotation shipped for months injecting nothing, and nothing said so: the target class was
+ * looked up by its simple name, which never resolves, and the mirrors were {@code static final}
+ * scalars whose values javac had already folded into every use site.
+ *
+ * <p>
+ * Both failures were invisible because there was no test. This one drives the injector against a
+ * stand-in "dependency" declared right here, so the mechanism is checked without needing a mod
+ * installed - and without the check quietly turning into an assertion about that mod's balance.
+ */
+class VersionedInjectionTest {
+
+    private static final String FAKE_MOD = "com.sbancuz.plannh.VersionedInjectionTest$Dependency";
+
+    /** Stands in for the mod: static fields, one of them private, one renamed since an old release. */
+    @SuppressWarnings("unused")
+    static final class Dependency {
+
+        static int SPEED = 42;
+        private static final double[] TABLE = { 1.5, 2.5 };
+        private static int HIDDEN = 77;
+        static int RENAMED_NEW = 7;
+        /** Only the old name exists here, which is the mod version a fallthrough has to cope with. */
+        static int LEGACY_NAME = 5;
+        /** A field whose type the mod changed out from under the mirror. */
+        static String TYPE_CHANGED = "no longer a number";
+        int notStatic = 3;
+    }
+
+    @Versioned.Mod(modId = "fakemod", sinceVersion = "1.0")
+    static final class Holder {
+
+        @Versioned.Class(FAKE_MOD)
+        static class Mirror {
+
+            static int SPEED = 1;
+            static double[] TABLE = { 0.0 };
+            static int notStatic = 111;
+            static int ABSENT = 222;
+            static int HIDDEN = 444;
+            static int TYPE_CHANGED = 666;
+
+            @Versioned.Constant("RENAMED_NEW")
+            @Versioned.Constant("RENAMED_OLD")
+            static int renamed = 333;
+
+            /** The first name is the one this dependency does not have, so it must try the second. */
+            @Versioned.Constant("MODERN_NAME")
+            @Versioned.Constant("LEGACY_NAME")
+            static int renamedSinceThisVersion = 555;
+        }
+    }
+
+    /** A mirror that kept its final, which is the shape that made the whole thing a no-op. */
+    @Versioned.Mod(modId = "fakemod", sinceVersion = "1.0")
+    static final class FinalHolder {
+
+        @Versioned.Class(FAKE_MOD)
+        static class Mirror {
+
+            static final int SPEED = 1;
+        }
+    }
+
+    /** A mirror pointed at a class the dependency does not have. */
+    @Versioned.Mod(modId = "fakemod", sinceVersion = "1.0")
+    static final class MovedHolder {
+
+        @Versioned.Class("com.sbancuz.plannh.NoSuchClassAnywhere")
+        static class Mirror {
+
+            static int SPEED = 1;
+        }
+    }
+
+    @BeforeEach
+    void resetMirrors() {
+        Holder.Mirror.SPEED = 1;
+        Holder.Mirror.TABLE = new double[] { 0.0 };
+        Holder.Mirror.notStatic = 111;
+        Holder.Mirror.ABSENT = 222;
+        Holder.Mirror.HIDDEN = 444;
+        Holder.Mirror.TYPE_CHANGED = 666;
+        Holder.Mirror.renamed = 333;
+        Holder.Mirror.renamedSinceThisVersion = 555;
+    }
+
+    /** The headline: after injection the mirror holds the dependency's number, not PlanNH's. */
+    @Test
+    void aMirrorTakesTheDependencysValue() {
+        VersionedInjector.inject(Holder.class);
+
+        assertEquals(Dependency.SPEED, Holder.Mirror.SPEED);
+    }
+
+    /** Arrays were the only thing that ever worked, so they have to keep working. */
+    @Test
+    void aTableIsCopiedWhole() {
+        VersionedInjector.inject(Holder.class);
+
+        assertArrayEquals(new double[] { 1.5, 2.5 }, Holder.Mirror.TABLE);
+    }
+
+    /** Mods keep their constants private more often than not, so private is not a reason to give up. */
+    @Test
+    void aPrivateFieldIsStillRead() {
+        VersionedInjector.inject(Holder.class);
+
+        assertEquals(77, Holder.Mirror.HIDDEN, "HIDDEN is private on the dependency");
+    }
+
+    /**
+     * The version-dependent lookup: one PlanNH constant, several names the mod has called it, first
+     * that resolves wins. This is what lets a mirror survive a rename without a second mirror.
+     */
+    @Test
+    void aRenamedFieldIsFoundUnderItsCurrentName() {
+        VersionedInjector.inject(Holder.class);
+
+        assertEquals(Dependency.RENAMED_NEW, Holder.Mirror.renamed);
+    }
+
+    /**
+     * The half that actually needs the loop: the name listed first is the one a newer mod uses, this
+     * dependency only has the older one, so resolving it means trying past a miss rather than giving
+     * up at the first name.
+     */
+    @Test
+    void anOlderDependencyIsFoundUnderThePreviousName() {
+        VersionedInjector.inject(Holder.class);
+
+        assertEquals(Dependency.LEGACY_NAME, Holder.Mirror.renamedSinceThisVersion);
+    }
+
+    /** A field the dependency does not have leaves the fallback alone rather than zeroing it. */
+    @Test
+    void aMissingFieldLeavesTheFallback() {
+        VersionedInjector.inject(Holder.class);
+
+        assertEquals(222, Holder.Mirror.ABSENT);
+    }
+
+    /**
+     * A mod that changed a field's type leaves the fallback alone. The value is found, so the miss is
+     * not a missing field - it is a value the mirror cannot hold, and writing it is what would throw.
+     */
+    @Test
+    void aFieldWhoseTypeChangedLeavesTheFallback() {
+        VersionedInjector.inject(Holder.class);
+
+        assertEquals(666, Holder.Mirror.TYPE_CHANGED);
+    }
+
+    /** An instance field is not a constant to mirror, and reading it would need an instance. */
+    @Test
+    void anInstanceFieldIsNotTreatedAsAConstant() {
+        VersionedInjector.inject(Holder.class);
+
+        assertEquals(111, Holder.Mirror.notStatic);
+    }
+
+    /**
+     * A final mirror is refused outright. Writing it would appear to work while every use site kept
+     * the folded literal, which is exactly the silence this replaced.
+     *
+     * <p>
+     * Read reflectively on purpose. {@code FinalHolder.Mirror.SPEED} written plainly is folded into
+     * this test too, so the assertion would read the literal 1 whatever the field held and would pass
+     * even if the injector had written it.
+     *
+     * <p>
+     * This pins the outcome, not which layer produced it: without the injector's own check the JVM
+     * refuses the write anyway and the field is equally untouched. The check earns its place by saying
+     * "drop the final" instead of reporting a type error, and {@code VersionedMirrorShapeTest} is what
+     * actually stops a final mirror being written in the first place.
+     */
+    @Test
+    void aFinalMirrorIsRefused() throws ReflectiveOperationException {
+        VersionedInjector.inject(FinalHolder.class);
+
+        final Field untouched = FinalHolder.Mirror.class.getDeclaredField("SPEED");
+        untouched.setAccessible(true);
+        assertEquals(1, untouched.getInt(null), "a final mirror must be left alone, not written behind its use sites");
+    }
+
+    /** A class the dependency moved costs its own mirrors, not the launch. */
+    @Test
+    void aMissingSourceClassIsSurvivable() {
+        VersionedInjector.inject(MovedHolder.class);
+
+        assertEquals(1, MovedHolder.Mirror.SPEED);
+    }
+
+    /** A class with no {@code @Versioned.Mod} is simply not ours to fill in. */
+    @Test
+    void anUnannotatedHolderIsIgnored() {
+        VersionedInjector.inject(String.class);
+    }
+}

--- a/src/test/java/com/sbancuz/plannh/VersionedInjectionTest.java
+++ b/src/test/java/com/sbancuz/plannh/VersionedInjectionTest.java
@@ -12,14 +12,9 @@ import com.sbancuz.plannh.annotation.Versioned;
 import com.sbancuz.plannh.annotation.VersionedInjector;
 
 /**
- * The annotation shipped for months injecting nothing, and nothing said so: the target class was
- * looked up by its simple name, which never resolves, and the mirrors were {@code static final}
- * scalars whose values javac had already folded into every use site.
- *
- * <p>
- * Both failures were invisible because there was no test. This one drives the injector against a
- * stand-in "dependency" declared right here, so the mechanism is checked without needing a mod
- * installed - and without the check quietly turning into an assertion about that mod's balance.
+ * Drives the injector against a stand-in "dependency" declared right here, so the mechanism is
+ * checked without needing a mod installed - and without the check quietly turning into an assertion
+ * about that mod's balance.
  */
 class VersionedInjectionTest {
 
@@ -174,7 +169,7 @@ class VersionedInjectionTest {
 
     /**
      * A final mirror is refused outright. Writing it would appear to work while every use site kept
-     * the folded literal, which is exactly the silence this replaced.
+     * the folded literal.
      *
      * <p>
      * Read reflectively on purpose. {@code FinalHolder.Mirror.SPEED} written plainly is folded into

--- a/src/test/java/com/sbancuz/plannh/VersionedMirrorShapeTest.java
+++ b/src/test/java/com/sbancuz/plannh/VersionedMirrorShapeTest.java
@@ -1,0 +1,99 @@
+package com.sbancuz.plannh;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * A {@code @Versioned.Class} mirror must not declare final fields.
+ *
+ * <p>
+ * {@code static final int X = 100} is a JLS 4.12.4 constant variable: javac writes 100 into every use
+ * site and the field is never read again, so injecting into it changes nothing at all. That is not a
+ * hypothetical - every scalar mirror in this codebase was written that way, and the injection had been
+ * a no-op for as long as the annotation existed.
+ *
+ * <p>
+ * Checked in the source rather than by reflection because reflection cannot see the difference: a
+ * final field with an injected value and a final field the compiler folded look identical from the
+ * outside. The declaration is the only place the distinction is visible.
+ */
+class VersionedMirrorShapeTest {
+
+    private static final Path MAIN = Path.of("src/main/java");
+    private static final String MIRROR = "@Versioned.Class";
+
+    @Test
+    void noVersionedMirrorDeclaresAFinalField() {
+        assertTrue(Files.isDirectory(MAIN), "sources are not where this test expects them: " + MAIN.toAbsolutePath());
+
+        final List<String> offenders = new ArrayList<>();
+        for (final Path source : javaSources()) {
+            offenders.addAll(finalFieldsInMirrors(source));
+        }
+
+        assertEquals(
+            List.of(),
+            offenders,
+            "a final mirror is compiled into its use sites, so @Versioned can never change it");
+    }
+
+    private static List<Path> javaSources() {
+        try (Stream<Path> sources = Files.walk(MAIN)) {
+            return sources.filter(
+                p -> p.toString()
+                    .endsWith(".java"))
+                .toList();
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Walks the body of each annotated mirror by brace depth. Crude, but the shape being looked for is
+     * a field declaration a few lines below a known annotation, and a parser would be more machinery
+     * than the rule is worth.
+     */
+    private static List<String> finalFieldsInMirrors(final Path source) {
+        final List<String> offenders = new ArrayList<>();
+        final List<String> lines;
+        try {
+            lines = Files.readAllLines(source);
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        for (int i = 0; i < lines.size(); i++) {
+            if (!lines.get(i)
+                .contains(MIRROR)) continue;
+
+            int depth = 0;
+            for (int j = i; j < lines.size(); j++) {
+                final String line = lines.get(j);
+                depth += count(line, '{') - count(line, '}');
+                if (depth > 0 && line.contains("static final ") && line.contains(";")) {
+                    offenders.add(source.getFileName() + ": " + line.trim());
+                }
+                if (depth == 0 && j > i) break;
+            }
+        }
+        return offenders;
+    }
+
+    private static int count(final String line, final char c) {
+        int seen = 0;
+        for (int i = 0; i < line.length(); i++) {
+            if (line.charAt(i) == c) seen++;
+        }
+        return seen;
+    }
+}

--- a/src/test/java/com/sbancuz/plannh/VersionedMirrorShapeTest.java
+++ b/src/test/java/com/sbancuz/plannh/VersionedMirrorShapeTest.java
@@ -18,9 +18,7 @@ import org.junit.jupiter.api.Test;
  *
  * <p>
  * {@code static final int X = 100} is a JLS 4.12.4 constant variable: javac writes 100 into every use
- * site and the field is never read again, so injecting into it changes nothing at all. That is not a
- * hypothetical - every scalar mirror in this codebase was written that way, and the injection had been
- * a no-op for as long as the annotation existed.
+ * site and the field is never read again, so injecting into it changes nothing at all.
  *
  * <p>
  * Checked in the source rather than by reflection because reflection cannot see the difference: a

--- a/src/test/java/com/sbancuz/plannh/annotation/VersionedAsmSweepTest.java
+++ b/src/test/java/com/sbancuz/plannh/annotation/VersionedAsmSweepTest.java
@@ -1,0 +1,141 @@
+package com.sbancuz.plannh.annotation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import cpw.mods.fml.common.discovery.ASMDataTable;
+
+/**
+ * The sweep over FML's annotation table, which is how the injector is actually entered in a game.
+ *
+ * <p>
+ * The branch worth pinning is the one that skips a provider whose mod is absent. It exists because the
+ * old sweep called {@code Class.forName} on every annotated provider unconditionally: a provider names
+ * its mod's types throughout, so on a pack without that mod the load is what fails - and the catch
+ * clause did not cover {@code LinkageError}, so it would have taken preInit with it.
+ *
+ * <p>
+ * A holder records in a static initializer that it was loaded at all, and the tests read that. Class
+ * literals do not trigger initialization (JLS 12.4.1), so naming a holder to build the table is safe;
+ * only the injector loading it can set the flag.
+ */
+class VersionedAsmSweepTest {
+
+    /**
+     * Set from a holder's static initializer, which is the only way to see that it was loaded at all.
+     * One-way on purpose: a class initializes once per JVM, so this cannot be reset between tests and
+     * is only sound for a holder no test ever expects to be loaded.
+     */
+    static final class Loaded {
+
+        static boolean absent;
+    }
+
+    /** Stands in for an installed mod's class. */
+    static final class Dependency {
+
+        static int SPEED = 42;
+    }
+
+    private static final String DEPENDENCY = "com.sbancuz.plannh.annotation.VersionedAsmSweepTest$Dependency";
+
+    @Versioned.Mod(modId = "presentmod", sinceVersion = "1.0")
+    static final class PresentHolder {
+
+        @Versioned.Class(DEPENDENCY)
+        static class Mirror {
+
+            static int SPEED = 1;
+        }
+    }
+
+    @Versioned.Mod(modId = "absentmod", sinceVersion = "1.0")
+    static final class AbsentHolder {
+
+        static {
+            Loaded.absent = true;
+        }
+
+        @Versioned.Class(DEPENDENCY)
+        static class Mirror {
+
+            static int SPEED = 1;
+        }
+    }
+
+    private static ASMDataTable tableNaming(final String... holderClassNames) {
+        final ASMDataTable table = new ASMDataTable();
+        for (final String holder : holderClassNames) {
+            final String modId = holder.endsWith("AbsentHolder") ? "absentmod" : "presentmod";
+            table.addASMData(null, Versioned.Mod.class.getName(), holder, null, Map.of("modId", modId));
+        }
+        return table;
+    }
+
+    /**
+     * Injection is what the positive cases assert, rather than a load flag: a class initializes once,
+     * so a flag set by the first test that touches a holder can never be cleared for the next one.
+     */
+    @BeforeEach
+    void resetMirrors() {
+        PresentHolder.Mirror.SPEED = 1;
+    }
+
+    /** The mod is installed, so its provider is loaded and its mirrors filled from the table entry. */
+    @Test
+    void aPresentModsProviderIsInjected() {
+        VersionedInjector.injectAll(tableNaming(PresentHolder.class.getName()), modId -> true);
+
+        assertEquals(Dependency.SPEED, PresentHolder.Mirror.SPEED);
+    }
+
+    /**
+     * The one that matters: an absent mod's provider must not be touched at all. Loading it is the
+     * failure, so asserting on its mirror would be too late - the flag says whether it was loaded.
+     */
+    @Test
+    void anAbsentModsProviderIsNeverLoaded() {
+        VersionedInjector.injectAll(tableNaming(AbsentHolder.class.getName()), modId -> false);
+
+        assertFalse(Loaded.absent, "a provider was classloaded for a mod that is not installed");
+        // Reading the mirror initializes the mirror, never the holder around it, so this is safe to
+        // ask and says the skip happened before any field was written too.
+        assertEquals(1, AbsentHolder.Mirror.SPEED);
+    }
+
+    /** One absent mod must not stop the providers either side of it from being filled in. */
+    @Test
+    void anAbsentModDoesNotStopTheRest() {
+        VersionedInjector.injectAll(
+            tableNaming(AbsentHolder.class.getName(), PresentHolder.class.getName()),
+            modId -> !"absentmod".equals(modId));
+
+        assertFalse(Loaded.absent);
+        assertEquals(Dependency.SPEED, PresentHolder.Mirror.SPEED);
+    }
+
+    /**
+     * A holder the jar no longer has. FML's table is built from bytes on disk, so a stale entry is
+     * possible, and it must cost that entry rather than the launch.
+     */
+    @Test
+    void aHolderThatIsNotOnTheClasspathIsSurvivable() {
+        VersionedInjector.injectAll(tableNaming("com.sbancuz.plannh.NoSuchProvider"), modId -> true);
+    }
+
+    /** An entry with no modId recorded is swept rather than skipped; there is nothing to check it against. */
+    @Test
+    void anEntryWithoutAModIdIsStillSwept() {
+        final ASMDataTable table = new ASMDataTable();
+        table.addASMData(null, Versioned.Mod.class.getName(), PresentHolder.class.getName(), null, Map.of());
+
+        VersionedInjector.injectAll(table, modId -> false);
+
+        assertEquals(Dependency.SPEED, PresentHolder.Mirror.SPEED);
+    }
+}


### PR DESCRIPTION
The LLM didn't seem to the existing @Versioned much, so it applied these fixes.

You're welcome to override or throw away these changes (I did not test them extensively), but I thought I should post them in case it is useful

---------------------

`@Versioned` has never injected anything. Two independent faults, either alone enough, plus a third that could stop the game loading.

### Fixed

- **The target class never resolved.** The fallback was
  `Class.forName(inner.getSimpleName())`, which always throws; the mirror was
  skipped before any field was reached, so the existing warning never fired.
  `@Versioned.Class` now requires the class named in full.
- **The mirrors were compiled away.** A `static final int` with a literal
  initializer is a JLS 4.12.4 constant variable, folded into every use site, so
  the write landed where nothing reads. Mirrors are now non-final: reads of
  `AE2Provider`'s `TileInscriber` mirror went from 0 `getstatic` to 4, and its
  three `ConstantValue` attributes are gone.
- **An absent mod could take preInit down.** `injectAll` loaded every annotated
  provider regardless, catching only `ReflectiveOperationException` - a provider
  names its mod's types throughout, so the load raises `NoClassDefFoundError`.
  The mod id is now read from the ASM table and checked before anything loads.
- **Private constants were unreadable**, for want of a `setAccessible`. AE2's
  mirrors are public so it never showed; most mods keep constants private.
- **`Unsafe` is gone**, with its seven `[removal]` warnings. It was only needed
  to write a `static final`, which mirrors no longer are.

### Added

- `@Versioned.Constant` is `@Repeatable`, so one constant can follow a field the
  dependency renamed: one annotation per name, newest first, first that resolves
  wins. Drift is reported against the earliest version any name was expected under.

### Tests

- `VersionedInjectionTest` - the mechanism, against a stand-in dependency declared
  in the test, so no mod is needed and no assertion drifts into claiming something
  about that mod's balance.
- `VersionedAsmSweepTest` - the FML sweep, including that an absent mod's provider
  is never classloaded.
- `VersionedMirrorShapeTest` - fails if a mirror declares a final field. A source
  check, because reflection cannot tell an injected final from a folded one.

### Not in scope

Reading a field off every constant of a dependency enum, and reading enum names as
a list. Both are wanted; neither has a caller on `dev`.

### For review

- `modPresent` and `installed` look like one predicate written twice. They are
  not: with no Forge to ask, one must answer "proceed" and the other "do not warn".
- `@Versioned.Class(clazz = ...)` stays a trap for an optional mod, since reading
  a Class-valued element whose class is absent throws `TypeNotPresentException`.
  The sweep contains that now and the javadoc points at `value()`. Say if the
  element should go.
- On AE2 rv3-beta-1017, `TileMolecularAssembler.MAX_PROCESSING_TIME` logs one
  warning per launch - AE2 has no such field there. Worth leaving: on the same
  class, `ACCELERATION_TAX` is absent in 987 and 997 and present in 1017, so a
  mirror missing from the pinned version is the case this annotation exists for.