### PR TITLE
Add machine sharing groups

### DIFF
--- a/src/main/java/com/sbancuz/plannh/data/MachineConfig.java
+++ b/src/main/java/com/sbancuz/plannh/data/MachineConfig.java
@@ -118,6 +118,18 @@ public class MachineConfig {
         return result;
     }
 
+    /**
+     * Takes another node's machine settings, for the members of a machine group: they are one
+     * machine, so they run at one tier with one set of upgrades. The machine count is left alone -
+     * it is how much of that machine each recipe asks for, not part of what the machine is.
+     */
+    public void copySettingsFrom(final MachineConfig other) {
+        final Object count = settings.get(Settings.MACHINES.key());
+        settings.clear();
+        settings.putAll(other.settings);
+        if (count != null) settings.put(Settings.MACHINES.key(), count);
+    }
+
     public int getMachineCount() {
         return getInt(Settings.MACHINES.key());
     }

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/GraphDataAdapter.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/GraphDataAdapter.java
@@ -17,6 +17,7 @@ public class GraphDataAdapter implements JsonDeserializer<GraphData> {
             .getAsString()) {
             case "note" -> Serializer.GSON.fromJson(json, Note.class);
             case "group" -> Serializer.GSON.fromJson(json, Group.class);
+            case MachineGroup.TYPE -> Serializer.GSON.fromJson(json, MachineGroup.class);
             case "summary" -> Serializer.GSON.fromJson(json, Summary.class);
             default -> throw new IllegalArgumentException("Invalid type detected during GroupData deserialization");
         };

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/Group.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/Group.java
@@ -29,6 +29,12 @@ public class Group extends GraphData {
     private boolean clampNodes;
     private boolean coverChildren;
     /**
+     * The player's statement that the recipes framed here run on the same machines, so the header
+     * may add their machine counts up per type. Purely a display claim - the balancer never sees
+     * it, and an old chart reads back as false, which is the behaviour it already had.
+     */
+    private boolean machineSharing;
+    /**
      * Sorted for the same reason the graph's own maps are, and for one more: Gson builds a
      * SortedMap field as a TreeMap but a Map keyed on anything but String as an insertion-ordered
      * LinkedTreeMap, so the declared type here is what makes a reloaded group iterate like a

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/Group.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/Group.java
@@ -29,19 +29,6 @@ public class Group extends GraphData {
     private boolean clampNodes;
     private boolean coverChildren;
     /**
-     * The player's statement that the recipes framed here run on the same machines, so their
-     * machine counts add up per type in the header. An old chart reads back as false, which is the
-     * behaviour it already had.
-     */
-    private boolean machineSharing;
-    /**
-     * How many machines the shared pool is allowed to be, or 0 for as many as it takes. This is
-     * the only part of a sharing group the solver reads: a positive capacity caps the group's
-     * summed machine time, so the chart is balanced to fit the hardware that exists instead of
-     * being measured after the fact. Ignored while {@link #machineSharing} is off.
-     */
-    private int machineCapacity;
-    /**
      * Sorted for the same reason the graph's own maps are, and for one more: Gson builds a
      * SortedMap field as a TreeMap but a Map keyed on anything but String as an insertion-ordered
      * LinkedTreeMap, so the declared type here is what makes a reloaded group iterate like a

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/Group.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/Group.java
@@ -29,11 +29,18 @@ public class Group extends GraphData {
     private boolean clampNodes;
     private boolean coverChildren;
     /**
-     * The player's statement that the recipes framed here run on the same machines, so the header
-     * may add their machine counts up per type. Purely a display claim - the balancer never sees
-     * it, and an old chart reads back as false, which is the behaviour it already had.
+     * The player's statement that the recipes framed here run on the same machines, so their
+     * machine counts add up per type in the header. An old chart reads back as false, which is the
+     * behaviour it already had.
      */
     private boolean machineSharing;
+    /**
+     * How many machines the shared pool is allowed to be, or 0 for as many as it takes. This is
+     * the only part of a sharing group the solver reads: a positive capacity caps the group's
+     * summed machine time, so the chart is balanced to fit the hardware that exists instead of
+     * being measured after the fact. Ignored while {@link #machineSharing} is off.
+     */
+    private int machineCapacity;
     /**
      * Sorted for the same reason the graph's own maps are, and for one more: Gson builds a
      * SortedMap field as a TreeMap but a Map keyed on anything but String as an insertion-ordered

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/MachineGroup.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/MachineGroup.java
@@ -1,0 +1,39 @@
+package com.sbancuz.plannh.data.flowchart;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * A group whose recipes run on the same machines. A plain {@link Group} frames a part of the chart
+ * and says nothing about the hardware; this one is a claim about it, so it holds one machine type
+ * only (by recipe handler, never by the display name a player can rewrite), its members share one
+ * configuration, and their machine counts add up into a single pool the solver can be asked to fit.
+ *
+ * <p>
+ * A separate type rather than a flag on {@link Group}: the capacity, the single-type rule and the
+ * shared settings mean nothing for an ordinary group, and the canvas draws this one differently so
+ * the two are not mistaken for each other.
+ */
+@Getter
+@Setter
+public class MachineGroup extends Group {
+
+    public static final String TYPE = "machine_group";
+
+    /**
+     * How many machines the pool is, or 0 for as many as it takes. A positive capacity caps the
+     * group's summed machine time in the solve, so the chart is balanced to fit the hardware that
+     * exists instead of being measured after the fact.
+     */
+    private int machineCapacity;
+
+    public MachineGroup() {
+        // GraphData names a fresh chart element after its type, which spells this one "Machine_group".
+        setHeader("Machine Group");
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+}

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/Serializer.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/Serializer.java
@@ -391,7 +391,9 @@ public final class Serializer {
         }
 
         for (final JsonElement elem : root.getAsJsonArray("groups")) {
-            final Group group = GSON.fromJson(elem, Group.class);
+            // Through GraphData, not Group: the type field decides whether this is a plain group or
+            // a machine group, and reading it as Group would drop the machine group's own fields.
+            final Group group = (Group) GSON.fromJson(elem, GraphData.class);
             graph.groups.put(group.getId(), group);
         }
 

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/balancer/ModelBuilder.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/balancer/ModelBuilder.java
@@ -118,6 +118,33 @@ public final class ModelBuilder {
         return this;
     }
 
+    /**
+     * One capacity row per machine-sharing pool: the machines framed by a capped group may spend
+     * no more machine time between them than the group has machines. A machine's own time is its
+     * extent times the seconds one craft takes, so the row is {@code Σ extent_i * durTicks_i/TPS <=
+     * capacity} - the same number the group header shows, held as a constraint instead of read off
+     * afterwards. In count space the variable already IS machine time, so the coefficient is 1.
+     *
+     * <p>
+     * Nothing is added when the chart has no capped group, which is every chart that never touched
+     * the feature. Requires {@link #extents(double[])} or {@link #extentCounts()}.
+     */
+    public ModelBuilder pools() {
+        require(extents, "extents() or extentCounts()");
+        final ModelData model = ctx.model;
+        for (int p = 0; p < model.pools.size(); p++) {
+            final ModelData.Pool pool = model.pools.get(p);
+            final Expression row = m.addExpression("pool_" + p);
+            for (final int machine : pool.machines()) {
+                row.set(
+                    extentVars[machine],
+                    countsSpace ? 1.0 : model.machines.get(machine).durTicks / (double) Numerics.TICKS_PER_SECOND);
+            }
+            row.upper(pool.capacity());
+        }
+        return this;
+    }
+
     /** One nonnegative flow (items/s) variable per drawn edge. */
     public ModelBuilder flows() {
         final ModelData model = ctx.model;

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/balancer/ModelData.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/balancer/ModelData.java
@@ -12,6 +12,7 @@ import com.sbancuz.plannh.data.MachineConfig;
 import com.sbancuz.plannh.data.flowchart.Edge;
 import com.sbancuz.plannh.data.flowchart.Graph;
 import com.sbancuz.plannh.data.flowchart.Group;
+import com.sbancuz.plannh.data.flowchart.MachineGroup;
 import com.sbancuz.plannh.data.flowchart.Node;
 
 /**
@@ -164,14 +165,14 @@ public final class ModelData {
      */
     private void buildPools(final Graph graph) {
         for (final Group group : graph.getGroups()) {
-            if (!group.isMachineSharing() || group.getMachineCapacity() <= 0) continue;
+            if (!(group instanceof final MachineGroup machineGroup) || machineGroup.getMachineCapacity() <= 0) continue;
             final List<Integer> members = new ArrayList<>();
             for (final UUID nodeId : group.getNodeIds()) {
                 final Integer m = machineIndex.get(nodeId);
                 if (m != null) members.add(m);
             }
             if (members.isEmpty()) continue;
-            pools.add(new Pool(List.copyOf(members), group.getMachineCapacity()));
+            pools.add(new Pool(List.copyOf(members), machineGroup.getMachineCapacity()));
         }
     }
 

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/balancer/ModelData.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/balancer/ModelData.java
@@ -11,6 +11,7 @@ import javax.annotation.Nullable;
 import com.sbancuz.plannh.data.MachineConfig;
 import com.sbancuz.plannh.data.flowchart.Edge;
 import com.sbancuz.plannh.data.flowchart.Graph;
+import com.sbancuz.plannh.data.flowchart.Group;
 import com.sbancuz.plannh.data.flowchart.Node;
 
 /**
@@ -96,12 +97,20 @@ public final class ModelData {
     /** One gate: an ingredient component in one direction, covering the listed ports. */
     public record Gate(boolean input, List<Integer> ports) {}
 
+    /**
+     * One machine-sharing group with a capacity: the machines that run on the same hardware and how
+     * many machines that hardware is. Only groups the player capped are built - a sharing group
+     * without a capacity constrains nothing, so it never reaches the model.
+     */
+    public record Pool(List<Integer> machines, int capacity) {}
+
     public final List<Machine> machines = new ArrayList<>();
     public final Map<UUID, Integer> machineIndex = new HashMap<>();
     public final List<EdgeData> edges = new ArrayList<>();
     public final List<ConnectedPort> connectedPorts = new ArrayList<>();
     public final Map<Long, Integer> portLookup = new HashMap<>();
     public final List<Gate> gates = new ArrayList<>();
+    public final List<Pool> pools = new ArrayList<>();
     public int[] portGate;
     public int[] portComponent;
     /** Packed lexicographic per-gate weights from the type's heuristics. */
@@ -138,6 +147,7 @@ public final class ModelData {
                 .add(e);
         }
 
+        buildPools(graph);
         buildGates();
         final boolean[] gateInput = new boolean[gates.size()];
         for (int g = 0; g < gates.size(); g++) {
@@ -145,6 +155,24 @@ public final class ModelData {
                 .input();
         }
         gateWeights = heuristics.gateWeights(gates.size(), gateInput);
+    }
+
+    /**
+     * The capped machine-sharing groups, as machine indices. A group holds node ids by geometry, so
+     * a node that has since left the chart is skipped, and a group left with nothing to constrain
+     * (no machines, or a capacity of zero) is not a pool at all.
+     */
+    private void buildPools(final Graph graph) {
+        for (final Group group : graph.getGroups()) {
+            if (!group.isMachineSharing() || group.getMachineCapacity() <= 0) continue;
+            final List<Integer> members = new ArrayList<>();
+            for (final UUID nodeId : group.getNodeIds()) {
+                final Integer m = machineIndex.get(nodeId);
+                if (m != null) members.add(m);
+            }
+            if (members.isEmpty()) continue;
+            pools.add(new Pool(List.copyOf(members), group.getMachineCapacity()));
+        }
     }
 
     /**

--- a/src/main/java/com/sbancuz/plannh/data/flowchart/balancer/Solver.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/balancer/Solver.java
@@ -71,6 +71,7 @@ public final class Solver {
     public static SolveResult flowMinimal(final SolveContext ctx, final Set<Integer> open, final double qtyCap) {
         final Handles h = ModelBuilder.over(ctx)
             .extents(autoLower(ctx))
+            .pools()
             .flows()
             .externals()
             .conservation()
@@ -88,6 +89,7 @@ public final class Solver {
     public static SolveResult externalsLp(final SolveContext ctx, final Set<Integer> open) {
         final Handles h = ModelBuilder.over(ctx)
             .extents(autoLower(ctx))
+            .pools()
             .flows()
             .externals()
             .conservation()
@@ -114,6 +116,7 @@ public final class Solver {
         for (int growth = 0; growth <= n.maxMGrowths; growth++) {
             final Handles h = ModelBuilder.over(ctx)
                 .extents(autoLower(ctx))
+                .pools()
                 .flows()
                 .externals()
                 .gates(bigM)
@@ -157,6 +160,7 @@ public final class Solver {
     public static SolveResult fixedQuantity(final SolveContext ctx, final Set<Integer> open) {
         final Handles h = ModelBuilder.over(ctx)
             .extents(autoLower(ctx))
+            .pools()
             .flows()
             .externals()
             .conservation()
@@ -178,6 +182,7 @@ public final class Solver {
         for (int growth = 0; growth <= n.maxMGrowths; growth++) {
             final Handles h = ModelBuilder.over(ctx)
                 .extents(autoLower(ctx))
+                .pools()
                 .flows()
                 .externals()
                 .gates(bigM)
@@ -209,6 +214,7 @@ public final class Solver {
     public static StageOutcome canonicalize(final SolveContext ctx, final Set<Integer> open, final StageOutcome s3) {
         final Handles h = ModelBuilder.over(ctx)
             .extents(autoLower(ctx))
+            .pools()
             .flows()
             .externals()
             .conservation()
@@ -411,6 +417,7 @@ public final class Solver {
     public static SolveResult extentFlow(final SolveContext ctx, final boolean inputPriority) {
         final ModelBuilder natural = ModelBuilder.over(ctx)
             .extentCounts()
+            .pools()
             .extentsWeighted(i -> 1.0)
             .flows()
             .portRows(inputPriority);
@@ -428,6 +435,7 @@ public final class Solver {
         }
         final ModelBuilder rescue = ModelBuilder.over(ctx)
             .extentCounts()
+            .pools()
             .extentsWeighted(i -> 1.0)
             .flows()
             .externals()

--- a/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
@@ -41,6 +41,7 @@ import com.sbancuz.plannh.data.flowchart.Edge;
 import com.sbancuz.plannh.data.flowchart.Graph;
 import com.sbancuz.plannh.data.flowchart.GraphData;
 import com.sbancuz.plannh.data.flowchart.Group;
+import com.sbancuz.plannh.data.flowchart.MachineGroup;
 import com.sbancuz.plannh.data.flowchart.Node;
 import com.sbancuz.plannh.data.flowchart.Note;
 import com.sbancuz.plannh.data.flowchart.Plan;
@@ -54,6 +55,9 @@ import com.sbancuz.plannh.nei.NodeLookupContext;
 
 import codechicken.lib.config.ConfigTag;
 import codechicken.nei.NEIClientConfig;
+import codechicken.nei.recipe.GuiRecipeTab;
+import codechicken.nei.recipe.IRecipeHandler;
+import codechicken.nei.recipe.RecipeHandlerRef;
 import lombok.Getter;
 
 public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interactable, IViewport, IDraggable {
@@ -508,6 +512,7 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
             final boolean contained = group.getNodeIds()
                 .contains(node.id);
             if (inside && !contained) {
+                if (group instanceof final MachineGroup machineGroup && !joinsMachineGroup(machineGroup, node)) continue;
                 group.getNodeIds()
                     .add(node.id);
             } else if (!inside && contained) {
@@ -515,6 +520,43 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
                     .remove(node.id);
             }
         }
+    }
+
+    /**
+     * Whether a node may join this machine group, and if it may, the settings it joins under. The
+     * group is one machine, so every member has to be the same one: identity is the NEI recipe
+     * handler rather than the machine's display name, which a player can rewrite. The first node in
+     * sets what the machine is; the ones after it are admitted only if they run on the same handler,
+     * and they take the group's configuration, since one machine cannot be at two tiers at once.
+     */
+    private boolean joinsMachineGroup(final MachineGroup group, final Node node) {
+        Node member = null;
+        for (final UUID memberId : group.getNodeIds()) {
+            final Node other = graph.nodes.get(memberId);
+            if (other != null) {
+                member = other;
+                break;
+            }
+        }
+        if (member == null) return true;
+        if (!handlerOf(member).equals(handlerOf(node))) return false;
+        node.machineConfig.copySettingsFrom(member.machineConfig);
+        return true;
+    }
+
+    /**
+     * The NEI handler a node's recipe came from, as its registered handler name. Read off the
+     * handler rather than off {@code RecipeId}, whose getter for the same string is spelled
+     * differently across NEI versions, so this holds for the version the mod builds against and the
+     * one the pack ships. The empty string when the handler is gone, which groups a chart's
+     * unresolvable nodes together and is as good an answer as any.
+     */
+    private static String handlerOf(final Node node) {
+        if (node.recipeId == null) return "";
+        final IRecipeHandler handler = RecipeHandlerRef.of(node.recipeId).handler;
+        if (handler == null) return "";
+        return GuiRecipeTab.getHandlerInfo(handler)
+            .getHandlerName();
     }
 
     public void rebuildNodeWidgets() {
@@ -1342,8 +1384,16 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     }
 
     public void addGroup(int x, int y) {
+        addGroup(x, y, new Group());
+    }
+
+    /** A group whose recipes share one machine; see {@link MachineGroup}. */
+    public void addMachineGroup(int x, int y) {
+        addGroup(x, y, new MachineGroup());
+    }
+
+    private void addGroup(final int x, final int y, final Group group) {
         PlanAPI.recordEdit(graph, () -> {
-            final Group group = new Group();
             group.setX(x);
             group.setY(y);
 

--- a/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/CanvasWidget.java
@@ -506,13 +506,14 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     private void updateNodeGroupMembership(final Node node) {
         for (final Group group : graph.groups.values()) {
             if (group.isCollapsed()) continue;
-            final boolean inside = node.x >= group.getX() && node.x < group.getX() + group.getWidth()
-                && node.y >= group.getY()
-                && node.y < group.getY() + group.getHeight();
+            final boolean inside = isInside(group, node);
             final boolean contained = group.getNodeIds()
                 .contains(node.id);
             if (inside && !contained) {
-                if (group instanceof final MachineGroup machineGroup && !joinsMachineGroup(machineGroup, node)) continue;
+                if (group instanceof final MachineGroup machineGroup) {
+                    joinsMachineGroup(machineGroup, node);
+                    continue;
+                }
                 group.getNodeIds()
                     .add(node.id);
             } else if (!inside && contained) {
@@ -523,25 +524,52 @@ public class CanvasWidget extends ParentWidget<CanvasWidget> implements Interact
     }
 
     /**
-     * Whether a node may join this machine group, and if it may, the settings it joins under. The
-     * group is one machine, so every member has to be the same one: identity is the NEI recipe
-     * handler rather than the machine's display name, which a player can rewrite. The first node in
-     * sets what the machine is; the ones after it are admitted only if they run on the same handler,
-     * and they take the group's configuration, since one machine cannot be at two tiers at once.
+     * Takes a node into a machine group under the group's settings. One machine cannot be at two
+     * tiers at once, so a joining node runs the way the group already runs.
      */
     private boolean joinsMachineGroup(final MachineGroup group, final Node node) {
-        Node member = null;
-        for (final UUID memberId : group.getNodeIds()) {
-            final Node other = graph.nodes.get(memberId);
-            if (other != null) {
-                member = other;
-                break;
-            }
+        final Node member = memberOf(group);
+        if (member != null) {
+            if (!handlerOf(member).equals(handlerOf(node))) return false;
+            node.machineConfig.copySettingsFrom(member.machineConfig);
         }
-        if (member == null) return true;
-        if (!handlerOf(member).equals(handlerOf(node))) return false;
-        node.machineConfig.copySettingsFrom(member.machineConfig);
+        group.getNodeIds()
+            .add(node.id);
         return true;
+    }
+
+    /**
+     * Whether a machine group would turn this node away. The group is one machine, so every member
+     * has to be the same one: identity is the NEI recipe handler rather than the machine's display
+     * name, which a player can rewrite. The first node in sets what the machine is; a node running
+     * anything else does not belong in the frame, which is why a drag that would drop it there is
+     * sent back rather than quietly leaving it inside a group it is not part of.
+     */
+    public boolean refusesNode(final Node node) {
+        for (final Group group : graph.groups.values()) {
+            if (!(group instanceof final MachineGroup machineGroup) || group.isCollapsed()) continue;
+            if (!isInside(group, node) || group.getNodeIds()
+                .contains(node.id)) continue;
+            final Node member = memberOf(machineGroup);
+            if (member != null && !handlerOf(member).equals(handlerOf(node))) return true;
+        }
+        return false;
+    }
+
+    /** Any node already in the group, which is what the group's one machine is; null while empty. */
+    @Nullable
+    private Node memberOf(final MachineGroup group) {
+        for (final UUID memberId : group.getNodeIds()) {
+            final Node member = graph.nodes.get(memberId);
+            if (member != null) return member;
+        }
+        return null;
+    }
+
+    private static boolean isInside(final Group group, final Node node) {
+        return node.x >= group.getX() && node.x < group.getX() + group.getWidth()
+            && node.y >= group.getY()
+            && node.y < group.getY() + group.getHeight();
     }
 
     /**

--- a/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
+++ b/src/main/java/com/sbancuz/plannh/gui/FlowchartScreen.java
@@ -139,6 +139,18 @@ public class FlowchartScreen extends ModularScreen {
                                 .color(PlannhColors.CONTEXT_BORDER.getColor()))
                         .overlay(
                             IKey.str("Add Group")
+                                .color(Color.WHITE.main)))
+                    .child(new ButtonWidget<>().onMousePressed(_ -> {
+                        canvas.addMachineGroup(canvas.getCanvasMouseX(), canvas.getCanvasMouseY());
+                        return true;
+                    })
+                        .fullWidth()
+                        .background(
+                            new Rectangle().color(PlannhColors.CONTEXT_BG.getColor()),
+                            new Rectangle().hollow()
+                                .color(PlannhColors.CONTEXT_BORDER.getColor()))
+                        .overlay(
+                            IKey.lang("plannh.gui.group.add_machine_group")
                                 .color(Color.WHITE.main))));
 
         mainColumn.child(

--- a/src/main/java/com/sbancuz/plannh/gui/GroupWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/GroupWidget.java
@@ -2,7 +2,9 @@ package com.sbancuz.plannh.gui;
 
 import static com.sbancuz.plannh.data.flowchart.Group.GROUP_MIN_W;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -11,15 +13,22 @@ import com.cleanroommc.modularui.api.drawable.IKey;
 import com.cleanroommc.modularui.drawable.DynamicDrawable;
 import com.cleanroommc.modularui.drawable.GuiTextures;
 import com.cleanroommc.modularui.drawable.Rectangle;
+import com.cleanroommc.modularui.screen.RichTooltip;
 import com.cleanroommc.modularui.screen.viewport.ModularGuiContext;
+import com.cleanroommc.modularui.utils.Alignment;
 import com.cleanroommc.modularui.utils.Color;
 import com.cleanroommc.modularui.value.BoolValue;
 import com.cleanroommc.modularui.widgets.ButtonWidget;
 import com.cleanroommc.modularui.widgets.ColorPickerDialog;
 import com.cleanroommc.modularui.widgets.CycleButtonWidget;
+import com.cleanroommc.modularui.widgets.TextWidget;
 import com.cleanroommc.modularui.widgets.ToggleButton;
 import com.cleanroommc.modularui.widgets.layout.Flow;
+import com.sbancuz.plannh.data.flowchart.Graph;
 import com.sbancuz.plannh.data.flowchart.Group;
+import com.sbancuz.plannh.data.flowchart.Node;
+import com.sbancuz.plannh.data.flowchart.balancer.BalanceResult;
+import com.sbancuz.plannh.data.flowchart.balancer.Balancer;
 
 import lombok.Getter;
 
@@ -67,6 +76,12 @@ public final class GroupWidget extends GroupableWidget<GroupWidget, Group> {
             .reverseLayout();
 
         buttonRow.child(new CloseButtonWidget(this))
+            .child(
+                new ToggleButton().value(new BoolValue.Dynamic(data::isMachineSharing, data::setMachineSharing))
+                    .overlay(
+                        IKey.str("MS")
+                            .color(Color.WHITE.main))
+                    .addTooltipLine("Toggle Machine Sharing: sum the machine counts of the recipes in this group"))
             .child(new ToggleButton().value(new BoolValue.Dynamic(data::isCoverChildren, val -> {
                 data.setCoverChildren(val);
                 if (val) canvas.fitGroupToChildren(data);
@@ -95,12 +110,71 @@ public final class GroupWidget extends GroupableWidget<GroupWidget, Group> {
                         if (was && !val) canvas.rebuildNodeWidgets();
                     })));
 
+        topRow.child(loadLabel());
         topRow.child(buttonRow);
 
         mainColumn.child(topRow);
         mainColumn.child(areaWidget);
 
         child(mainColumn);
+    }
+
+    /**
+     * The group's machine load: for every machine type inside the frame, the counts of its nodes
+     * summed. A node's count is already machine-time - a recipe filling a third of a machine reads
+     * 0.33 - so the sum is what one type has to be able to run at once if the group's recipes share
+     * hardware. Nothing here constrains the solve; the group is the player's own statement that
+     * these recipes run on the same machines, and the header just adds up what the nodes already
+     * say. Sorted by load so the busiest type leads, name breaking ties.
+     */
+    private List<Map.Entry<String, Double>> machineLoad() {
+        if (!getData().isMachineSharing()) return List.of();
+        final Graph graph = canvas.getGraph();
+        final BalanceResult balance = graph.balance();
+        if (balance == null) return List.of();
+        final Map<String, Double> byMachine = new HashMap<>();
+        for (final UUID nodeId : getData().getNodeIds()) {
+            final Node node = graph.nodes.get(nodeId);
+            if (node == null) continue;
+            final Balancer.NodeBalance nb = balance.nodeBalances()
+                .get(nodeId);
+            if (nb == null || nb.operations() <= 0) continue;
+            byMachine.merge(node.machineName, nb.operations(), Double::sum);
+        }
+        final List<Map.Entry<String, Double>> out = new ArrayList<>(byMachine.entrySet());
+        out.sort(
+            Map.Entry.<String, Double>comparingByValue()
+                .reversed()
+                .thenComparing(Map.Entry.comparingByKey()));
+        return out;
+    }
+
+    /**
+     * The load next to the group's name: the count alone for a single machine type, a type count
+     * when there are several. Machine names are as long as GregTech feels like, and the row already
+     * holds the name field and the buttons, so the header carries the number and the names live in
+     * the tooltip, which is pinned below the row - the default position sits beside the widget and
+     * trims every line to whatever screen width is left there. Empty when the group does not claim
+     * machine sharing or holds no solved nodes, which collapses the widget away.
+     */
+    private TextWidget<?> loadLabel() {
+        return new TextWidget<>(IKey.dynamic(() -> {
+            final List<Map.Entry<String, Double>> load = machineLoad();
+            if (load.isEmpty()) return "";
+            if (load.size() == 1) return "×" + GuiHelper.formatCount(
+                load.get(0)
+                    .getValue());
+            return load.size() + " types";
+        })).color(PlannhColors.SUMMARY_TEXT_MUTED.getColor())
+            .textAlign(Alignment.CenterRight)
+            .tooltipPos(RichTooltip.Pos.BELOW)
+            .tooltipAutoUpdate(true)
+            .tooltipDynamic(tooltip -> {
+                for (final Map.Entry<String, Double> entry : machineLoad()) {
+                    tooltip.add("×" + GuiHelper.formatCount(entry.getValue()) + " " + entry.getKey())
+                        .newLine();
+                }
+            });
     }
 
     @Override

--- a/src/main/java/com/sbancuz/plannh/gui/GroupWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/GroupWidget.java
@@ -2,13 +2,9 @@ package com.sbancuz.plannh.gui;
 
 import static com.sbancuz.plannh.data.flowchart.Group.GROUP_MIN_W;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
-import net.minecraft.util.StatCollector;
 
 import com.cleanroommc.modularui.api.IPanelHandler;
 import com.cleanroommc.modularui.api.drawable.IKey;
@@ -29,6 +25,7 @@ import com.cleanroommc.modularui.widgets.layout.Flow;
 import com.sbancuz.plannh.api.PlanAPI;
 import com.sbancuz.plannh.data.flowchart.Graph;
 import com.sbancuz.plannh.data.flowchart.Group;
+import com.sbancuz.plannh.data.flowchart.MachineGroup;
 import com.sbancuz.plannh.data.flowchart.Node;
 import com.sbancuz.plannh.data.flowchart.balancer.BalanceResult;
 import com.sbancuz.plannh.data.flowchart.balancer.Balancer;
@@ -46,9 +43,10 @@ public final class GroupWidget extends GroupableWidget<GroupWidget, Group> {
 
         coverChildren(GROUP_MIN_W, 0);
 
+        final int borderWidth = data instanceof MachineGroup ? 4 : 2;
         background(
             new DynamicDrawable(
-                () -> new Rectangle().hollow(2)
+                () -> new Rectangle().hollow(borderWidth)
                     .color(data.getColor())));
 
         data.getChildren()
@@ -71,6 +69,14 @@ public final class GroupWidget extends GroupableWidget<GroupWidget, Group> {
             .fullWidth()
             .background(new DynamicDrawable(() -> new Rectangle().color(data.getColor())));
 
+        // The badge, and the doubled border below it, are what tell a machine group from an
+        // ordinary one at a glance: the two behave differently and are easy to mistake otherwise.
+        if (data instanceof MachineGroup) {
+            topRow.child(
+                new TextWidget<>(IKey.lang("plannh.gui.group.machine_badge")).color(Color.WHITE.main)
+                    .textAlign(Alignment.CenterLeft)
+                    .addTooltipLine(IKey.lang("plannh.gui.group.machine_group_tooltip")));
+        }
         topRow.child(new HeaderTextWidget(this, data::getColor));
 
         Flow buttonRow = FlowchartFlow.row(this)
@@ -78,18 +84,12 @@ public final class GroupWidget extends GroupableWidget<GroupWidget, Group> {
             .childPadding(2)
             .reverseLayout();
 
-        buttonRow.child(new CloseButtonWidget(this))
-            .child(new ToggleButton().value(new BoolValue.Dynamic(data::isMachineSharing, val -> {
-                data.setMachineSharing(val);
-                resolve();
-            }))
-                .overlay(
-                    IKey.str("MS")
-                        .color(Color.WHITE.main))
-                .addTooltipLine(IKey.lang("plannh.gui.group.machine_sharing")))
-            .child(capacityButton("+", 1))
-            .child(capacityButton("-", -1))
-            .child(new ToggleButton().value(new BoolValue.Dynamic(data::isCoverChildren, val -> {
+        buttonRow.child(new CloseButtonWidget(this));
+        if (data instanceof final MachineGroup machineGroup) {
+            buttonRow.child(capacityButton(machineGroup, "+", 1))
+                .child(capacityButton(machineGroup, "-", -1));
+        }
+        buttonRow.child(new ToggleButton().value(new BoolValue.Dynamic(data::isCoverChildren, val -> {
                 data.setCoverChildren(val);
                 if (val) canvas.fitGroupToChildren(data);
                 areaWidget.configureCoverChildren();
@@ -117,7 +117,7 @@ public final class GroupWidget extends GroupableWidget<GroupWidget, Group> {
                         if (was && !val) canvas.rebuildNodeWidgets();
                     })));
 
-        topRow.child(loadLabel());
+        if (data instanceof final MachineGroup machineGroup) topRow.child(loadLabel(machineGroup));
         topRow.child(buttonRow);
 
         mainColumn.child(topRow);
@@ -131,13 +131,13 @@ public final class GroupWidget extends GroupableWidget<GroupWidget, Group> {
      * takes" and the state every chart starts in. The capacity is a solve input, so a step is an
      * edit like any other: recorded for undo and version-bumped so the chart re-balances under it.
      */
-    private ButtonWidget<?> capacityButton(final String label, final int step) {
+    private ButtonWidget<?> capacityButton(final MachineGroup group, final String label, final int step) {
         return new ButtonWidget<>().overlay(
             IKey.str(label)
                 .color(Color.WHITE.main))
             .onMousePressed(_ -> {
                 PlanAPI.recordEdit(canvas.getGraph(), () -> {
-                    getData().setMachineCapacity(Math.max(0, getData().getMachineCapacity() + step));
+                    group.setMachineCapacity(Math.max(0, group.getMachineCapacity() + step));
                     resolve();
                 });
                 return true;
@@ -152,62 +152,58 @@ public final class GroupWidget extends GroupableWidget<GroupWidget, Group> {
     }
 
     /**
-     * The group's machine load: for every machine type inside the frame, the counts of its nodes
-     * summed. A node's count is already machine-time - a recipe filling a third of a machine reads
-     * 0.33 - so the sum is what one type has to be able to run at once if the group's recipes share
-     * hardware. Nothing here constrains the solve; the group is the player's own statement that
-     * these recipes run on the same machines, and the header just adds up what the nodes already
-     * say. Sorted by load so the busiest type leads, name breaking ties.
+     * The pool's load: the machine counts of the framed nodes, summed. A node's count is already
+     * machine time - a recipe filling a third of a machine reads 0.33 - so the sum is how much of
+     * the one machine the group's recipes ask for between them. Every member runs the same handler
+     * under the same settings, which is what makes the sum a single machine's worth of work rather
+     * than an addition of unlike things.
      */
-    private List<Map.Entry<String, Double>> machineLoad() {
-        if (!getData().isMachineSharing()) return List.of();
+    private double machineLoad() {
         final Graph graph = canvas.getGraph();
         final BalanceResult balance = graph.balance();
-        if (balance == null) return List.of();
-        final Map<String, Double> byMachine = new HashMap<>();
+        if (balance == null) return 0;
+        double load = 0;
         for (final UUID nodeId : getData().getNodeIds()) {
-            final Node node = graph.nodes.get(nodeId);
-            if (node == null) continue;
             final Balancer.NodeBalance nb = balance.nodeBalances()
                 .get(nodeId);
             if (nb == null || nb.operations() <= 0) continue;
-            byMachine.merge(node.machineName, nb.operations(), Double::sum);
+            load += nb.operations();
         }
-        final List<Map.Entry<String, Double>> out = new ArrayList<>(byMachine.entrySet());
-        out.sort(
-            Map.Entry.<String, Double>comparingByValue()
-                .reversed()
-                .thenComparing(Map.Entry.comparingByKey()));
-        return out;
+        return load;
+    }
+
+    /** The machine the group stands for, from any member; empty until a node is framed. */
+    private String machineName() {
+        final Graph graph = canvas.getGraph();
+        for (final UUID nodeId : getData().getNodeIds()) {
+            final Node node = graph.nodes.get(nodeId);
+            if (node != null) return node.machineName;
+        }
+        return "";
     }
 
     /**
-     * The load next to the group's name: the count alone for a single machine type, a type count
-     * when there are several. Machine names are as long as GregTech feels like, and the row already
-     * holds the name field and the buttons, so the header carries the number and the names live in
-     * the tooltip, which is pinned below the row - the default position sits beside the widget and
-     * trims every line to whatever screen width is left there. Empty when the group does not claim
-     * machine sharing or holds no solved nodes, which collapses the widget away.
+     * The load next to the group's name, against the capacity when one is set. Machine names are as
+     * long as GregTech feels like and the row already holds the name field and the buttons, so the
+     * header carries the number and the machine is named in the tooltip, which is pinned below the
+     * row - the default position sits beside the widget and trims to whatever screen width is left
+     * there. Empty for a group with no solved nodes, which collapses the widget away.
      */
-    private TextWidget<?> loadLabel() {
+    private TextWidget<?> loadLabel(final MachineGroup group) {
         return new TextWidget<>(IKey.dynamic(() -> {
-            final List<Map.Entry<String, Double>> load = machineLoad();
-            if (load.isEmpty()) return "";
-            final int capacity = getData().getMachineCapacity();
-            final String used = load.size() == 1 ? "×" + GuiHelper.formatCount(
-                load.get(0)
-                    .getValue())
-                : StatCollector.translateToLocalFormatted("plannh.gui.group.machine_types", load.size());
-            return capacity > 0 ? used + " / " + capacity : used;
+            final double load = machineLoad();
+            if (load <= 0) return "";
+            final String used = "×" + GuiHelper.formatCount(load);
+            return group.getMachineCapacity() > 0 ? used + " / " + group.getMachineCapacity() : used;
         })).color(PlannhColors.SUMMARY_TEXT_MUTED.getColor())
             .textAlign(Alignment.CenterRight)
             .tooltipPos(RichTooltip.Pos.BELOW)
             .tooltipAutoUpdate(true)
             .tooltipDynamic(tooltip -> {
-                for (final Map.Entry<String, Double> entry : machineLoad()) {
-                    tooltip.add("×" + GuiHelper.formatCount(entry.getValue()) + " " + entry.getKey())
-                        .newLine();
-                }
+                final double load = machineLoad();
+                if (load <= 0) return;
+                tooltip.add("×" + GuiHelper.formatCount(load) + " " + machineName())
+                    .newLine();
             });
     }
 

--- a/src/main/java/com/sbancuz/plannh/gui/GroupWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/GroupWidget.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import net.minecraft.util.StatCollector;
+
 import com.cleanroommc.modularui.api.IPanelHandler;
 import com.cleanroommc.modularui.api.drawable.IKey;
 import com.cleanroommc.modularui.drawable.DynamicDrawable;
@@ -24,6 +26,7 @@ import com.cleanroommc.modularui.widgets.CycleButtonWidget;
 import com.cleanroommc.modularui.widgets.TextWidget;
 import com.cleanroommc.modularui.widgets.ToggleButton;
 import com.cleanroommc.modularui.widgets.layout.Flow;
+import com.sbancuz.plannh.api.PlanAPI;
 import com.sbancuz.plannh.data.flowchart.Graph;
 import com.sbancuz.plannh.data.flowchart.Group;
 import com.sbancuz.plannh.data.flowchart.Node;
@@ -76,12 +79,16 @@ public final class GroupWidget extends GroupableWidget<GroupWidget, Group> {
             .reverseLayout();
 
         buttonRow.child(new CloseButtonWidget(this))
-            .child(
-                new ToggleButton().value(new BoolValue.Dynamic(data::isMachineSharing, data::setMachineSharing))
-                    .overlay(
-                        IKey.str("MS")
-                            .color(Color.WHITE.main))
-                    .addTooltipLine("Toggle Machine Sharing: sum the machine counts of the recipes in this group"))
+            .child(new ToggleButton().value(new BoolValue.Dynamic(data::isMachineSharing, val -> {
+                data.setMachineSharing(val);
+                resolve();
+            }))
+                .overlay(
+                    IKey.str("MS")
+                        .color(Color.WHITE.main))
+                .addTooltipLine(IKey.lang("plannh.gui.group.machine_sharing")))
+            .child(capacityButton("+", 1))
+            .child(capacityButton("-", -1))
             .child(new ToggleButton().value(new BoolValue.Dynamic(data::isCoverChildren, val -> {
                 data.setCoverChildren(val);
                 if (val) canvas.fitGroupToChildren(data);
@@ -117,6 +124,31 @@ public final class GroupWidget extends GroupableWidget<GroupWidget, Group> {
         mainColumn.child(areaWidget);
 
         child(mainColumn);
+    }
+
+    /**
+     * Steps the pool's capacity, floored at zero, which is the group's "as many machines as it
+     * takes" and the state every chart starts in. The capacity is a solve input, so a step is an
+     * edit like any other: recorded for undo and version-bumped so the chart re-balances under it.
+     */
+    private ButtonWidget<?> capacityButton(final String label, final int step) {
+        return new ButtonWidget<>().overlay(
+            IKey.str(label)
+                .color(Color.WHITE.main))
+            .onMousePressed(_ -> {
+                PlanAPI.recordEdit(canvas.getGraph(), () -> {
+                    getData().setMachineCapacity(Math.max(0, getData().getMachineCapacity() + step));
+                    resolve();
+                });
+                return true;
+            })
+            .addTooltipLine(IKey.lang("plannh.gui.group.machine_capacity"));
+    }
+
+    /** Marks the chart for a fresh solve; a pool's capacity and membership are model inputs. */
+    private void resolve() {
+        canvas.getGraph()
+            .markDirty();
     }
 
     /**
@@ -161,10 +193,12 @@ public final class GroupWidget extends GroupableWidget<GroupWidget, Group> {
         return new TextWidget<>(IKey.dynamic(() -> {
             final List<Map.Entry<String, Double>> load = machineLoad();
             if (load.isEmpty()) return "";
-            if (load.size() == 1) return "×" + GuiHelper.formatCount(
+            final int capacity = getData().getMachineCapacity();
+            final String used = load.size() == 1 ? "×" + GuiHelper.formatCount(
                 load.get(0)
-                    .getValue());
-            return load.size() + " types";
+                    .getValue())
+                : StatCollector.translateToLocalFormatted("plannh.gui.group.machine_types", load.size());
+            return capacity > 0 ? used + " / " + capacity : used;
         })).color(PlannhColors.SUMMARY_TEXT_MUTED.getColor())
             .textAlign(Alignment.CenterRight)
             .tooltipPos(RichTooltip.Pos.BELOW)

--- a/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
@@ -617,6 +617,20 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget>
                 openNeiRecipe();
                 return true;
             }
+            // A machine group is one machine, so a node running another recipe handler has no place
+            // in it. There is nowhere to say so - the canvas has no message popup - so the drag
+            // simply does not take: the node goes back where it was picked up from.
+            if (dragging && canvas.refusesNode(node)) {
+                node.x = nodeStartX;
+                node.y = nodeStartY;
+                syncTransform(
+                    canvas.getGraph()
+                        .getZoom(),
+                    canvas.getGraph()
+                        .getPanX(),
+                    canvas.getGraph()
+                        .getPanY());
+            }
             dragging = false;
             canvas.recheckMembershipAndFit();
             PlanAPI.undoHistory()

--- a/src/main/resources/assets/plannh/lang/en_US.lang
+++ b/src/main/resources/assets/plannh/lang/en_US.lang
@@ -113,6 +113,11 @@ plannh.share.copy_to_clipboard=Plan exported to clipboard
 plannh.share.copy_from_clipboard=Plan imported from clipboard
 
 ## GUI
+## GUI - Groups
+plannh.gui.group.machine_sharing=Toggle Machine Sharing: sum the machine counts of the recipes in this group
+plannh.gui.group.machine_types=%d types
+plannh.gui.group.machine_capacity=Machines in the shared pool; 0 for as many as it takes
+
 ## GUI - Balancer
 plannh.gui.balancer_mode=Mode: %s
 plannh.gui.balancer_mode.none=Normal

--- a/src/main/resources/assets/plannh/lang/en_US.lang
+++ b/src/main/resources/assets/plannh/lang/en_US.lang
@@ -114,9 +114,10 @@ plannh.share.copy_from_clipboard=Plan imported from clipboard
 
 ## GUI
 ## GUI - Groups
-plannh.gui.group.machine_sharing=Toggle Machine Sharing: sum the machine counts of the recipes in this group
-plannh.gui.group.machine_types=%d types
-plannh.gui.group.machine_capacity=Machines in the shared pool; 0 for as many as it takes
+plannh.gui.group.add_machine_group=Add Machine Group
+plannh.gui.group.machine_badge=[M]
+plannh.gui.group.machine_group_tooltip=Machine group: every recipe framed here runs on the same machine, so they share its settings and their machine counts add up
+plannh.gui.group.machine_capacity=Machines in this group; 0 for as many as it takes
 
 ## GUI - Balancer
 plannh.gui.balancer_mode=Mode: %s


### PR DESCRIPTION
A chain often runs several recipes on the same machine, and the chart already knows the answer: every node's count is machine time, so a recipe filling a third of a machine reads 0.33. What was missing is saying which recipes share the hardware, and being able to plan against it.

A machine group is a group that stands for one machine. It takes in nodes of a single recipe handler, its members share the settings that decide duration, and their counts add up in its header. Giving it a machine count enters the solve as one row per group, the summed machine time held at or below the machines it has, so a chain that does not fit the hardware is reported as such instead of being measured after the fact. Ordinary groups are untouched, and a machine group without a count constrains nothing.

Not covered: minimizing the number of physical machines, which would add a machine-count term to the AUTO objective rather than a constraint.
