### PR TITLE
Format displayed numbers and keys with Locale.ROOT

### DIFF
--- a/src/main/java/com/sbancuz/plannh/data/flowchart/balancer/BalanceMode.java
+++ b/src/main/java/com/sbancuz/plannh/data/flowchart/balancer/BalanceMode.java
@@ -1,5 +1,6 @@
 package com.sbancuz.plannh.data.flowchart.balancer;
 
+import java.util.Locale;
 import java.util.Set;
 
 import net.minecraft.util.StatCollector;
@@ -72,6 +73,6 @@ public enum BalanceMode {
     public String displayName() {
         return StatCollector.translateToLocal(
             "plannh.gui.balancer_mode." + this.name()
-                .toLowerCase());
+                .toLowerCase(Locale.ROOT));
     }
 }

--- a/src/main/java/com/sbancuz/plannh/gui/GuiHelper.java
+++ b/src/main/java/com/sbancuz/plannh/gui/GuiHelper.java
@@ -1,5 +1,7 @@
 package com.sbancuz.plannh.gui;
 
+import java.util.Locale;
+
 import net.minecraft.client.Minecraft;
 
 import org.apache.commons.lang3.StringUtils;
@@ -23,8 +25,8 @@ public final class GuiHelper {
         if (Math.abs(count - rounded) < 5e-3 && (rounded != 0 || count == 0)) {
             return String.valueOf(rounded);
         }
-        return count > 0 && count < 0.01 ? trimTrailingZeros(String.format("%.5f", count))
-            : String.format("%.2f", count);
+        return count > 0 && count < 0.01 ? trimTrailingZeros(String.format(Locale.ROOT, "%.5f", count))
+            : String.format(Locale.ROOT, "%.2f", count);
     }
 
     public static String trimTrailingZeros(final String s) {
@@ -41,14 +43,14 @@ public final class GuiHelper {
         // Suffixes and base match NEI's and AE2's ReadableNumberConverter (both "kMGTPE" over 1000),
         // which is what a player reads everywhere else in the pack. G rather than B also keeps a
         // billion apart from the B fluid amounts already use for buckets.
-        if (rate >= 1e18f) return String.format("%.1fE", rate / 1e18f);
-        if (rate >= 1e15f) return String.format("%.1fP", rate / 1e15f);
-        if (rate >= 1e12f) return String.format("%.1fT", rate / 1e12f);
-        if (rate >= 1e9f) return String.format("%.1fG", rate / 1e9f);
-        if (rate >= 1e6f) return String.format("%.1fM", rate / 1e6f);
-        if (rate >= 1000f) return String.format("%.1fk", rate / 1000f);
-        if (rate >= 1f) return String.format("%.2f", rate);
-        return trimTrailingZeros(String.format("%.5f", rate));
+        if (rate >= 1e18f) return String.format(Locale.ROOT, "%.1fE", rate / 1e18f);
+        if (rate >= 1e15f) return String.format(Locale.ROOT, "%.1fP", rate / 1e15f);
+        if (rate >= 1e12f) return String.format(Locale.ROOT, "%.1fT", rate / 1e12f);
+        if (rate >= 1e9f) return String.format(Locale.ROOT, "%.1fG", rate / 1e9f);
+        if (rate >= 1e6f) return String.format(Locale.ROOT, "%.1fM", rate / 1e6f);
+        if (rate >= 1000f) return String.format(Locale.ROOT, "%.1fk", rate / 1000f);
+        if (rate >= 1f) return String.format(Locale.ROOT, "%.2f", rate);
+        return trimTrailingZeros(String.format(Locale.ROOT, "%.5f", rate));
     }
 
     public static void drawRectBorder(final int x, final int y, final int w, final int h, final int bw,

--- a/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
+++ b/src/main/java/com/sbancuz/plannh/gui/RecipeNodeWidget.java
@@ -4,6 +4,7 @@ import static org.lwjgl.opengl.GL11.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import java.util.function.IntConsumer;
 
@@ -375,7 +376,7 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget>
                 if (!simpleTiming.isEmpty()) simpleTiming.append("  ");
                 simpleTiming.append(simpleDurPerOp)
                     .append("t (")
-                    .append(String.format("%.1f", (float) simpleDurPerOp / GuiHelper.TICKS_PER_SECOND))
+                    .append(String.format(Locale.ROOT, "%.1f", (float) simpleDurPerOp / GuiHelper.TICKS_PER_SECOND))
                     .append("s)");
             }
             final Object rawVoltage = node.machineConfig.settings.get("voltage");
@@ -497,7 +498,7 @@ public class RecipeNodeWidget extends Widget<RecipeNodeWidget>
             if (!opsLine.isEmpty()) opsLine.append("  ");
             opsLine.append(durPerOp)
                 .append("t (")
-                .append(String.format("%.2f", (float) durPerOp / GuiHelper.TICKS_PER_SECOND))
+                .append(String.format(Locale.ROOT, "%.2f", (float) durPerOp / GuiHelper.TICKS_PER_SECOND))
                 .append("s)");
         }
         GuiDraw.drawText(opsLine.toString(), x, y, 1.0f, PlannhColors.ACCENT_BLUE.getColor(), false);

--- a/src/main/java/com/sbancuz/plannh/gui/summary/TotalsRow.java
+++ b/src/main/java/com/sbancuz/plannh/gui/summary/TotalsRow.java
@@ -1,5 +1,7 @@
 package com.sbancuz.plannh.gui.summary;
 
+import java.util.Locale;
+
 import com.cleanroommc.modularui.api.GuiAxis;
 import com.cleanroommc.modularui.api.drawable.IKey;
 import com.cleanroommc.modularui.drawable.Rectangle;
@@ -22,7 +24,8 @@ final class TotalsRow extends FlowchartFlow {
     TotalsRow(final FlowchartWidget<?, ?> panel, final Summary.Line.Totals totals, final Plan.Mode mode) {
         super(GuiAxis.X, panel);
         final String ops = GuiHelper.formatCount(totals.operations());
-        final String sec = String.format("%.2f", (double) totals.durationTicks() / GuiHelper.TICKS_PER_SECOND);
+        final String sec = String
+            .format(Locale.ROOT, "%.2f", (double) totals.durationTicks() / GuiHelper.TICKS_PER_SECOND);
         final IKey text = mode == Plan.Mode.THROUGHPUT ? IKey.lang("plannh.summary.totals.throughput", ops, sec)
             : IKey.lang("plannh.summary.totals.cycles", ops, totals.durationTicks(), sec);
         fullWidth().coverChildrenHeight(SummaryBody.LINE_H)


### PR DESCRIPTION
Counts, rates and durations were formatted with the default locale, so a Russian client showed "1,2k" while NEI and AE2 print "1.2k" everywhere else in the pack. Formatting now goes through Locale.ROOT, matching Config and SolverMessage, which also fixes RateDisplayTest failing on non-English locales.

The balance mode localization key was lowercased the same way, so a Turkish client would look up "balancer_mode.ınput" and show the raw key instead of the mode name.